### PR TITLE
feat: Plugin option projectRoot

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -106,6 +106,7 @@ class MpxWebpackPlugin {
           mode: this.options.mode,
           srcMode: this.options.srcMode,
           externalClasses: this.options.externalClasses,
+          projectRoot: this.options.projectRoot,
           extract: (content, type, resourcePath, index, selfResourcePath) => {
             if (index === -1) {
               const compilationMpx = compilation.__mpx__

--- a/packages/webpack-plugin/lib/wxml/wxml-loader.js
+++ b/packages/webpack-plugin/lib/wxml/wxml-loader.js
@@ -40,8 +40,9 @@ module.exports = function (content) {
   const usingComponents = []
 
   const mainCompilation = getMainCompilation(this._compilation)
-  const mode = mainCompilation.__mpx__.mode
-  const globalSrcMode = mainCompilation.__mpx__.srcMode
+  const __mpx__ = mainCompilation.__mpx__
+  const mode = __mpx__.mode
+  const globalSrcMode = __mpx__.srcMode
   const localSrcMode = loaderUtils.parseQuery(this.resourceQuery || '?').mode
   const srcMode = localSrcMode || globalSrcMode
 
@@ -61,7 +62,13 @@ module.exports = function (content) {
   )
 
   const attributes = ['image:src', 'audio:src', 'video:src', 'cover-image:src', 'import:src', 'include:src', `${config[mode].wxs.tag}:${config[mode].wxs.src}`]
-  const root = ''
+  let root = ''
+
+  if (__mpx__.projectRoot) {
+    // 如果有设置项目根路径，可以将src引用的文件由绝对引用改为相对引用，以便可以找到以“/”开头的路径引用文件
+    root = __mpx__.projectRoot
+  }
+
   const links = attrParse(content, function (tag, attr) {
     const res = attributes.find(function (a) {
       if (a.charAt(0) === ':') {


### PR DESCRIPTION
fix "Can't resolve module xx" when values of src in template files start with "/", which should be relative to project root