### PR TITLE
Update xfetch.js

### DIFF
--- a/packages/fetch/src/request.js
+++ b/packages/fetch/src/request.js
@@ -11,7 +11,8 @@ function transformReq (config) {
     set (val) {
       header = val
     },
-    enumerable: true
+    enumerable: true,
+    configurable: true
   }
   Object.defineProperties(config, {
     header: descriptor,

--- a/packages/fetch/src/xfetch.js
+++ b/packages/fetch/src/xfetch.js
@@ -20,8 +20,7 @@ export default class XFetch {
   addLowPriorityWhiteList (rules) {
     this.queue.addLowPriorityWhiteList(rules)
   }
-  fetch (rawConfig, priority) {
-    const config = JSON.parse(JSON.stringify(rawConfig))
+  fetch (config, priority) {
     const request = () => this.queue.request(config, priority)
     // middleware chain
     const chain = []

--- a/packages/fetch/src/xfetch.js
+++ b/packages/fetch/src/xfetch.js
@@ -20,7 +20,8 @@ export default class XFetch {
   addLowPriorityWhiteList (rules) {
     this.queue.addLowPriorityWhiteList(rules)
   }
-  fetch (config, priority) {
+  fetch (rawConfig, priority) {
+    const config = JSON.parse(JSON.stringify(rawConfig))
     const request = () => this.queue.request(config, priority)
     // middleware chain
     const chain = []


### PR DESCRIPTION
因为在transformReq中使用Object.defineProperties修改了config.header，
导致如果开发者再次将这个被修改过的config传入xfetch.fetch方法时，就会报如下错:

> Unhandled promise rejection TypeError: Cannot redefine property: header
>   at Object.defineProperties (<anonymous>)

![image](https://user-images.githubusercontent.com/24930493/64803129-bd6c3a80-d5be-11e9-9c70-96f2cdf4afd5.png)

虽然开发者可以手动深拷贝config来避免这个错误
不过如果可以在框架内帮助规避错误，又没有其他影响的话，就最好了😄