### PR TITLE
feat: option contentReplacer

### DIFF
--- a/packages/webpack-plugin/lib/content-replace-loader.js
+++ b/packages/webpack-plugin/lib/content-replace-loader.js
@@ -1,0 +1,13 @@
+module.exports = function (content) {
+  const loaderContext = this
+  loaderContext.cacheable()
+
+  const mpx = loaderContext._compilation.__mpx__
+  const callback = loaderContext.async()
+  const contentReplacer = mpx.contentReplacer
+  contentReplacer.replace({
+    content,
+    resourcePath: loaderContext.resourcePath
+  })
+    .then(newContent => callback(null, newContent), callback)
+}

--- a/packages/webpack-plugin/lib/content-replace-loader.js
+++ b/packages/webpack-plugin/lib/content-replace-loader.js
@@ -1,13 +1,14 @@
+const getMainCompilation = require('./utils/get-main-compilation')
+
 module.exports = function (content) {
   const loaderContext = this
   loaderContext.cacheable()
 
-  const mpx = loaderContext._compilation.__mpx__
-  const callback = loaderContext.async()
+  const mpx = getMainCompilation(loaderContext._compilation).__mpx__
   const contentReplacer = mpx.contentReplacer
-  contentReplacer.replace({
+  const { content: newContent } = contentReplacer.replace({
     content,
     resourcePath: loaderContext.resourcePath
   })
-    .then(newContent => callback(null, newContent), callback)
+  return newContent
 }

--- a/packages/webpack-plugin/lib/helpers.js
+++ b/packages/webpack-plugin/lib/helpers.js
@@ -2,6 +2,7 @@ const querystring = require('querystring')
 const loaderUtils = require('loader-utils')
 const normalize = require('./utils/normalize')
 const tryRequire = require('./utils/try-require')
+const contentReplaceLoaderPath = normalize.lib('content-replace-loader')
 const styleCompilerPath = normalize.lib('style-compiler/index')
 const templateCompilerPath = normalize.lib('template-compiler/index')
 const jsonCompilerPath = normalize.lib('json-compiler/index')
@@ -231,7 +232,7 @@ module.exports = function createHelpers (loaderContext, options, moduleId, isPro
   }
 
   function getLoaderString (type, part, index, scoped, withIssuer) {
-    let loader = getRawLoaderString(type, part, index, scoped)
+    let loader = getRawLoaderString(type, part, index, scoped) + ensureBang(contentReplaceLoaderPath)
     const lang = getLangString(type, part)
     if (type !== 'script' && type !== 'wxs') {
       loader = getExtractorString(type, index, withIssuer) + loader

--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -19,6 +19,7 @@ const RequireHeaderDependency = require('webpack/lib/dependencies/RequireHeaderD
 const RemovedModuleDependency = require('./dependency/RemovedModuleDependency')
 const SplitChunksPlugin = require('webpack/lib/optimize/SplitChunksPlugin')
 const createContentReplacer = require('./utils/content-replacer')
+const mpxJson = require('./utils/mpx-json')
 
 const isProductionLikeMode = options => {
   return options.mode === 'production' || !options.mode
@@ -191,6 +192,8 @@ class MpxWebpackPlugin {
     }
 
     mpx.contentReplacer = createContentReplacer(mpx)
+
+    mpxJson.setMpx(mpx)
 
     compiler.hooks.thisCompilation.tap('MpxWebpackPlugin', (compilation, { normalModuleFactory }) => {
       if (!compilation.__mpx__) {

--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -18,6 +18,7 @@ const HarmonyImportSideEffectDependency = require('webpack/lib/dependencies/Harm
 const RequireHeaderDependency = require('webpack/lib/dependencies/RequireHeaderDependency')
 const RemovedModuleDependency = require('./dependency/RemovedModuleDependency')
 const SplitChunksPlugin = require('webpack/lib/optimize/SplitChunksPlugin')
+const createContentReplacer = require('./utils/content-replacer')
 
 const isProductionLikeMode = options => {
   return options.mode === 'production' || !options.mode
@@ -159,6 +160,7 @@ class MpxWebpackPlugin {
     const mpx = {
       // pages全局记录，无需区分主包分包
       pagesMap: {},
+      options: this.options,
       componentsMap: {
         main: {}
       },
@@ -187,6 +189,8 @@ class MpxWebpackPlugin {
         sideEffects && sideEffects(additionalAssets)
       }
     }
+
+    mpx.contentReplacer = createContentReplacer(mpx)
 
     compiler.hooks.thisCompilation.tap('MpxWebpackPlugin', (compilation, { normalModuleFactory }) => {
       if (!compilation.__mpx__) {

--- a/packages/webpack-plugin/lib/json-compiler/index.js
+++ b/packages/webpack-plugin/lib/json-compiler/index.js
@@ -7,6 +7,7 @@ const parse = require('../parser')
 const config = require('../config')
 const normalize = require('../utils/normalize')
 const nativeLoaderPath = normalize.lib('native-loader')
+const contentReplaceLoaderPath = normalize.lib('content-replace-loader')
 const getResourcePath = require('../utils/get-resource-path')
 const mpxJSON = require('../utils/mpx-json')
 const toPosix = require('../utils/to-posix')
@@ -212,7 +213,7 @@ module.exports = function (raw) {
       currentComponentsMap[resourcePath] = componentPath
       if (ext === '.js') {
         const nativeLoaderOptions = mpx.loaderOptions ? '?' + JSON.stringify(mpx.loaderOptions) : ''
-        resource = '!!' + nativeLoaderPath + nativeLoaderOptions + '!' + resource
+        resource = '!!' + nativeLoaderPath + nativeLoaderOptions + '!' + contentReplaceLoaderPath + '!' + resource
       }
       if (subPackageRoot) {
         resource = addQuery(resource, {
@@ -395,7 +396,7 @@ module.exports = function (raw) {
               }
             }
             if (ext === '.js') {
-              resource = '!!' + nativeLoaderPath + '!' + resource
+              resource = '!!' + nativeLoaderPath + '!' + contentReplaceLoaderPath + '!' + resource
             }
             addEntrySafely(resource, name, callback)
           })

--- a/packages/webpack-plugin/lib/native-loader.js
+++ b/packages/webpack-plugin/lib/native-loader.js
@@ -111,11 +111,16 @@ module.exports = function (content) {
         tryEvalMPXJSON(callback)
       } else {
         if (typeExtMap['json']) {
-          fs.readFile(resourceName + typeExtMap['json'], (err, raw) => {
+          const resourcePath = resourceName + typeExtMap['json']
+          fs.readFile(resourcePath, (err, raw) => {
             if (err) {
               callback(err)
             } else {
-              callback(null, raw.toString('utf-8'))
+              const contentReplacer = mpx.contentReplacer
+              callback(null, contentReplacer.replace({
+                content: raw.toString('utf-8'),
+                resourcePath
+              }).content)
             }
           })
         } else {

--- a/packages/webpack-plugin/lib/utils/content-replacer.js
+++ b/packages/webpack-plugin/lib/utils/content-replacer.js
@@ -1,0 +1,51 @@
+const fs = require('fs')
+
+function createContentReplacer (mpx) {
+  async function replace (opts) {
+    const mode = mpx.mode
+    const srcMode = mpx.srcMode
+    const contentReplacer = mpx.options.contentReplacer
+
+    const { resourcePath, content } = opts
+    let ret
+    // return original content
+    if (!contentReplacer) {
+      ret = content
+    } else {
+      const replaceResult = await contentReplacer({
+        resourcePath,
+        content,
+        mode,
+        srcMode
+      })
+
+      if (replaceResult) {
+        if (replaceResult.content) {
+          ret = replaceResult.content
+        } else if (replaceResult.filePath) {
+          ret = await new Promise((resolve, reject) => {
+            fs.readFile(replaceResult.filePath, (err, raw) => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(raw.toString('utf-8'))
+              }
+            })
+          })
+        } else {
+          throw new Error('No replace result is found!')
+        }
+      } else {
+        // Nothing changed
+        ret = content
+      }
+    }
+    return ret
+  }
+
+  return {
+    replace
+  }
+}
+
+module.exports = createContentReplacer

--- a/packages/webpack-plugin/lib/utils/mpx-json.js
+++ b/packages/webpack-plugin/lib/utils/mpx-json.js
@@ -1,7 +1,19 @@
 const path = require('path')
 
+let _mpx
+
+function setMpx (mpx) {
+  _mpx = mpx
+}
+
 // 将JS生成JSON
+// TODO webpack alias support
 function compileMPXJSON ({ source, mode, filePath }) {
+  const contentReplacer = _mpx.contentReplacer
+  source = contentReplacer.replace({
+    resourcePath: filePath,
+    content: source
+  }).content
   // eslint-disable-next-line no-new-func
   const func = new Function('exports', 'require', 'module', '__filename', '__dirname', '__mpx_mode__', source)
   // 模拟commonJS执行
@@ -28,5 +40,6 @@ function compileMPXJSONText (opts) {
 
 module.exports = {
   compileMPXJSON,
-  compileMPXJSONText
+  compileMPXJSONText,
+  setMpx
 }


### PR DESCRIPTION
Pass a option `contentReplacer` for user to replace file content. Example:
```javascript
    new MpxWebpackPlugin({
      mode: 'qq',
      srcMode: 'wx',
      contentReplacer(opts) {
        const { resourcePath, content, mode, helper } = opts;
        let ret = false
        const PATH_PAGE_SUBPACK_STICKY = path.resolve(__dirname, '../src/subpack/pages/sticky');
        const PATH_PAGE_TEST = path.resolve(__dirname, '../src/pages/test');
        const PATH_PAGE_REPLACE_BASENAME = path.resolve(__dirname, '../src/pages/replace/index')
        const oExtName = helper.extname(resourcePath);
        if (oExtName !== '.mpx' && (resourcePath.indexOf(PATH_PAGE_SUBPACK_STICKY) === 0 || resourcePath.indexOf(PATH_PAGE_TEST) === 0)) {
          const filePath = PATH_PAGE_REPLACE_BASENAME + oExtName
          return {
            filePath,
            // or pass content directly
           // content: 'any content'
          }
        }
        return ret
      }
    })
```
But note that this option is ONLY implemented for native files by now.