### PR TITLE
fix: swan trackBy 

### DIFF
--- a/packages/webpack-plugin/lib/platform/template/wx/index.js
+++ b/packages/webpack-plugin/lib/platform/template/wx/index.js
@@ -36,8 +36,8 @@ module.exports = function getSpec ({ warn, error }) {
                 list[i] = i
               }
               listName = JSON.stringify(list)
-            } else {
               warn(`Number type loop variable is not support in baidu environment, please check variable: ${variableName}`)
+            } else {
               listName = varListName[1]
             }
           } else {
@@ -49,7 +49,10 @@ module.exports = function getSpec ({ warn, error }) {
           const indexName = attrsMap['wx:for-index'] || 'index'
           const keyName = attrsMap['wx:key'] || null
           let keyStr = ''
-          if (keyName) {
+          if (keyName &&
+            // 百度不支持在trackBy使用mustache语法
+            !/{{[^}]*}}/.test(keyName)
+          ) {
             if (keyName === '*this') {
               keyStr = ` trackBy ${itemName}`
             } else {

--- a/packages/webpack-plugin/test/platform/wx/template.spec.js
+++ b/packages/webpack-plugin/test/platform/wx/template.spec.js
@@ -74,6 +74,8 @@ describe('template should transform correct', function () {
     const input9 = `<view wx:for="{{8}}" wx:for-item="t1" wx:for-index="t2" wx:key="u1">123</view>`
     const input10 = `<view wx:for="{{list}}" wx:key="*this">123</view>`
     const input11 = `<view wx:for="{{list}}" wx:key="a-b">123</view>`
+    const input12 = `<view wx:for="{{list}}" wx:key="{{index}}">123</view>`
+    const input13 = `<view wx:for="{{list}}" wx:key="{{prefix}}Hey">123</view>`
 
     const output1 = compileAndParse(input1, { srcMode: 'wx', mode: 'swan' })
     const output2 = compileAndParse(input2, { srcMode: 'wx', mode: 'swan' })
@@ -86,6 +88,8 @@ describe('template should transform correct', function () {
     const output9 = compileAndParse(input9, { srcMode: 'wx', mode: 'swan' })
     const output10 = compileAndParse(input10, { srcMode: 'wx', mode: 'swan' })
     const output11 = compileAndParse(input11, { srcMode: 'wx', mode: 'swan' })
+    const output12 = compileAndParse(input12, { srcMode: 'wx', mode: 'swan' })
+    const output13 = compileAndParse(input13, { srcMode: 'wx', mode: 'swan' })
 
     expect(output1).toBe('<view s-for="item, index in list trackBy item.unique">123</view>')
     expect(output2).toBe('<view s-for="item, index in list">123</view>')
@@ -98,6 +102,8 @@ describe('template should transform correct', function () {
     expect(output9).toBe('<view s-for="t1, t2 in [0,1,2,3,4,5,6,7] trackBy t1[t2]">123</view>')
     expect(output10).toBe('<view s-for="item, index in list trackBy item">123</view>')
     expect(output11).toBe(`<view s-for="item, index in list trackBy item['a-b']">123</view>`)
+    expect(output12).toBe(`<view s-for="item, index in list">123</view>`)
+    expect(output13).toBe(`<view s-for="item, index in list">123</view>`)
   })
 })
 


### PR DESCRIPTION
Fix swan trackBy wrong number loop warning and remove trackBy when key contains mustache templates