### PR TITLE
feat: globalMpxAttrsFilter

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -233,7 +233,7 @@ class MpxWebpackPlugin {
           resolveMode: this.options.resolveMode,
           mode: this.options.mode,
           srcMode: this.options.srcMode,
-          options: this.options,
+          globalMpxAttrsFilter: this.options.globalMpxAttrsFilter,
           externalClasses: this.options.externalClasses,
           projectRoot: this.options.projectRoot,
           autoScopeRules: this.options.autoScopeRules,

--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -233,6 +233,7 @@ class MpxWebpackPlugin {
           resolveMode: this.options.resolveMode,
           mode: this.options.mode,
           srcMode: this.options.srcMode,
+          options: this.options,
           externalClasses: this.options.externalClasses,
           projectRoot: this.options.projectRoot,
           autoScopeRules: this.options.autoScopeRules,

--- a/packages/webpack-plugin/lib/template-compiler/compiler.js
+++ b/packages/webpack-plugin/lib/template-compiler/compiler.js
@@ -186,18 +186,24 @@ function isMpxCommentAttrs (content) {
   return /@mpx-attrs/.test(content)
 }
 
+function normalizePlatformMpxAttrsOpts (opts) {
+  const ret = {}
+  // Array to map for removing attributes
+  ret.remove = (opts.remove || []).reduce((acc, val) => {
+    acc[val] = true
+    return acc
+  }, {})
+  // Default adding map
+  ret.add = opts.add || {}
+  return ret
+}
+
 function produceMpxCommentAttrs (content) {
   const exp = /@mpx-attrs[^(]*?\(([\s\S]*)\)/.exec(content)[1].trim()
   const tmpOpts = evalMpxCommentExp(exp)
   // normalize
   Object.keys(tmpOpts).forEach(k => {
-    // Array to map for removing attributes
-    tmpOpts[k].remove = (tmpOpts[k].remove || []).reduce((acc, val) => {
-      acc[val] = true
-      return acc
-    }, {})
-    // Default adding map
-    tmpOpts[k].add = tmpOpts[k].add || {}
+    Object.assign(tmpOpts[k], normalizePlatformMpxAttrsOpts(tmpOpts[k]))
 
     if (k.indexOf(',') > -1) {
       const modes = k.split(',')
@@ -210,29 +216,33 @@ function produceMpxCommentAttrs (content) {
   curMpxComment = tmpOpts
 }
 
+function modifyAttrsFromCurMpxAttrOptions (attrs, curModeMpxComment) {
+  const removeMap = curModeMpxComment.remove
+  const addMap = curModeMpxComment.add
+
+  const newAttrs = []
+  attrs.forEach(attr => {
+    if (!removeMap[attr.name]) {
+      newAttrs.push(attr)
+    }
+  })
+
+  Object.keys(addMap).forEach(name => {
+    newAttrs.push({
+      name,
+      value: addMap[name]
+    })
+  })
+
+  return newAttrs
+}
+
 function consumeMpxCommentAttrs (attrs, mode) {
   let ret = attrs
   if (curMpxComment) {
     const curModeMpxComment = curMpxComment[mode]
     if (curModeMpxComment) {
-      const removeMap = curModeMpxComment.remove
-      const addMap = curModeMpxComment.add
-
-      const newAttrs = []
-      attrs.forEach(attr => {
-        if (!removeMap[attr.name]) {
-          newAttrs.push(attr)
-        }
-      })
-
-      Object.keys(addMap).forEach(name => {
-        newAttrs.push({
-          name,
-          value: addMap[name]
-        })
-      })
-
-      ret = newAttrs
+      ret = modifyAttrsFromCurMpxAttrOptions(attrs, curModeMpxComment)
     }
 
     // reset
@@ -764,6 +774,9 @@ function parse (template, options) {
         attrs = guardIESVGBug(attrs)
       }
 
+      if (options.globalMpxAttrsFilter) {
+        attrs = modifyAttrsFromCurMpxAttrOptions(attrs, normalizePlatformMpxAttrsOpts(options.globalMpxAttrsFilter({ tagName: tag, attrs, __mpx_mode__: mode }) || {}))
+      }
       attrs = consumeMpxCommentAttrs(attrs, mode)
 
       let element = createASTElement(tag, attrs, currentParent)

--- a/packages/webpack-plugin/lib/template-compiler/index.js
+++ b/packages/webpack-plugin/lib/template-compiler/index.js
@@ -41,7 +41,7 @@ module.exports = function (raw) {
     basename: path.basename(this.resource),
     isComponent: !!componentsMap[resourcePath],
     mode,
-    globalMpxAttrsFilter: mpx.options.globalMpxAttrsFilter,
+    globalMpxAttrsFilter: mpx.globalMpxAttrsFilter,
     externalClasses,
     srcMode: localSrcMode || globalSrcMode,
     isNative,

--- a/packages/webpack-plugin/lib/template-compiler/index.js
+++ b/packages/webpack-plugin/lib/template-compiler/index.js
@@ -41,6 +41,7 @@ module.exports = function (raw) {
     basename: path.basename(this.resource),
     isComponent: !!componentsMap[resourcePath],
     mode,
+    globalMpxAttrsFilter: mpx.options.globalMpxAttrsFilter,
     externalClasses,
     srcMode: localSrcMode || globalSrcMode,
     isNative,


### PR DESCRIPTION
Use example:
```javascript
    new MpxWebpackPlugin({
      mode: 'tt',
      srcMode: 'wx',
      // 统一处理不支持的属性
      globalMpxAttrsFilter(info) {
        const { __mpx_mode__, tagName, attrs } = info
        let ret = {}
        if (__mpx_mode__ === 'tt' && tagName === 'scroll-view') {
          ret.remove = ['enable-back-to-top']
        }
        return ret // 返回同@mpx-attrs的平台下声明
      },
    }),
```