### PR TITLE
修复转web时，redirectTo，navigateTo回调不生效的问题

### DIFF
--- a/packages/api-proxy/src/web/api/route/index.js
+++ b/packages/api-proxy/src/web/api/route/index.js
@@ -16,19 +16,21 @@ function redirectTo (options = {}) {
   if (router) {
     router.__mpxAction = { type: 'redirect' }
     return new Promise((resolve, reject) => {
-      router.replace({
-        path: options.url,
-        onComplete: () => {
+      router.replace(
+        {
+          path: options.url
+        },
+        () => {
           const res = { errMsg: 'redirectTo:ok' }
           webHandleSuccess(res, options.success, options.complete)
           resolve(res)
         },
-        onAbort: err => {
+        err => {
           const res = { errMsg: `redirectTo:fail ${err}` }
           webHandleFail(res, options.fail, options.complete)
           !options.fail && reject(res)
         }
-      })
+      )
     })
   }
 }
@@ -38,19 +40,21 @@ function navigateTo (options = {}) {
   if (router) {
     router.__mpxAction = { type: 'to' }
     return new Promise((resolve, reject) => {
-      router.push({
-        path: options.url,
-        onComplete: () => {
+      router.push(
+        {
+          path: options.url
+        },
+        () => {
           const res = { errMsg: 'navigateTo:ok', eventChannel: null }
           webHandleSuccess(res, options.success, options.complete)
           resolve(res)
         },
-        onAbort: err => {
+        err => {
           const res = { errMsg: err }
           webHandleFail(res, options.fail, options.complete)
           !options.fail && reject(res)
         }
-      })
+      )
     })
   }
 }


### PR DESCRIPTION
vue router[ push、 replace]方法参数位置错误