### PR TITLE
fix: 修复支付宝环境下for item为undefined时使用index作为key导致的崩溃

### DIFF
--- a/packages/webpack-plugin/lib/platform/template/wx/index.js
+++ b/packages/webpack-plugin/lib/platform/template/wx/index.js
@@ -106,6 +106,25 @@ module.exports = function getSpec ({ warn, error }) {
         swan () {
           return false
         },
+        ali (obj, data) {
+          const attrsMap = data.el.attrsMap
+          const indexName = attrsMap['wx:for-index'] || 'index'
+          const keyName = attrsMap['wx:key'] || null
+          if (!keyName) {
+            return false
+          }
+          if (indexName === keyName) {
+            return {
+              name: 'key',
+              value: `{{${keyName}}}`
+            }
+          } else {
+            return {
+              name: 'a:key',
+              value: keyName
+            }
+          }
+        },
         web ({ value }, { el }) {
           // vue的template中不能包含key，对应于小程序中的block
           if (el.tag === 'block') return false

--- a/packages/webpack-plugin/test/platform/wx/template/common.spec.js
+++ b/packages/webpack-plugin/test/platform/wx/template/common.spec.js
@@ -68,6 +68,20 @@ describe('common spec case', function () {
     expect(output14).toBe('<view s-for="t1, t2 in [0,1,2,3,4,5,6,7] trackBy t1">123</view>')
   })
 
+  it('should optimize key of for in ali', function () {
+    const input1 = `<view wx:for="{{list}}" wx:key="index" wx:for-index="index">123</view>`
+    const input2 = `<view wx:for="{{list}}" wx:key="k" wx:for-index="index">123</view>`
+    const input3 = `<view wx:for="{{list}}" wx:for-index="index">123</view>`
+
+    const output1 = compileAndParse(input1, { srcMode: 'wx', mode: 'ali' })
+    const output2 = compileAndParse(input2, { srcMode: 'wx', mode: 'ali' })
+    const output3 = compileAndParse(input3, { srcMode: 'wx', mode: 'ali' })
+
+    expect(output1).toBe('<view key="{{index}}" a:for="{{list}}" a:for-index="index">123</view>')
+    expect(output2).toBe('<view a:for="{{list}}" a:for-index="index" a:key="k">123</view>')
+    expect(output3).toBe('<view a:for="{{list}}" a:for-index="index">123</view>')
+  })
+
   it('should trans event binding for tt miniapp', function () {
     const input1 = `<test-comp1 bind:click="clickHandler">123</test-comp1>`
     const input1b = `<test-comp1 bindclick="clickHandler">123</test-comp1>`


### PR DESCRIPTION
Fixes #461