### PR TITLE
fix wx miniprogram external

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -59,7 +59,7 @@ function getPackageCacheGroup (packageName) {
 let loaderOptions
 
 const externalsMap = {
-  weui: /^weui-miniprogram/
+  weui: /weui-miniprogram/
 }
 
 const warnings = []


### PR DESCRIPTION
通过以下方式有条件的使用微信拓展组件，配合useExtendedLib配置，以达到小程序external的效果，这种方式引入的组件将不会计入代码包大小。现在的正则匹配不到external条件，会继续走后面的resolve的逻辑，导致找不到组件的错误。

``` javascript
const wxComponents = {
    "mp-icon": "/miniprogram_npm/weui-miniprogram/icon/icon",
    "mp-dialog": "/miniprogram_npm/weui-miniprogram/dialog/dialog"
  }
  module.exports = {
    "usingComponents": __mpx_mode__ === 'wx' 
      ? Object.assign({}, wxComponents)
      : {}
  }
```