### PR TITLE
小程序输出H5 支持 onResize 事件

### DIFF
--- a/packages/core/src/convertor/wxToWeb.js
+++ b/packages/core/src/convertor/wxToWeb.js
@@ -5,7 +5,7 @@ import { error } from '../helper/log'
 import { implemented } from '../core/implement'
 
 // 暂不支持的wx选项，后期需要各种花式支持
-const NOTSUPPORTS = ['moved', 'relations', 'pageLifetimes', 'definitionFilter', 'onPageNotFound', 'onShareAppMessage', 'onTabItemTap', 'onResize', 'pageShow', 'pageHide']
+const NOTSUPPORTS = ['moved', 'relations', 'pageLifetimes', 'definitionFilter', 'onPageNotFound', 'onShareAppMessage', 'onTabItemTap', 'pageShow', 'pageHide']
 
 function convertErrorDesc (key) {
   error(`Options.${key} is not supported in runtime conversion from wx to web.`, global.currentResource)

--- a/packages/core/src/platform/builtInMixins/index.js
+++ b/packages/core/src/platform/builtInMixins/index.js
@@ -7,6 +7,7 @@ import relationsMixin from './relationsMixin'
 import i18nMixin from './i18nMixin'
 import pageTitleMixin from './pageTitleMixin'
 import pageScrollMixin from './pageScrollMixin'
+import pageOnResizeMixin from './pageOnResizeMixin'
 
 export default function getBuiltInMixins (options, type) {
   let bulitInMixins = []
@@ -16,7 +17,8 @@ export default function getBuiltInMixins (options, type) {
       refsMixin(),
       pageTitleMixin(type),
       pageStatusMixin(type),
-      pageScrollMixin(type)
+      pageScrollMixin(type),
+      pageOnResizeMixin(type)
     ]
   } else {
     // 此为差异抹平类mixins，原生模式下也需要注入也抹平平台差异

--- a/packages/core/src/platform/builtInMixins/pageOnResizeMixin.js
+++ b/packages/core/src/platform/builtInMixins/pageOnResizeMixin.js
@@ -1,0 +1,28 @@
+/**
+ * 输出 H5 页面 onresize
+ * @param mixinType
+ * @returns {{deactivated(): void, activated(): void}}
+ */
+export default function onResize (mixinType) {
+  if (mixinType === 'page' && __mpx_mode__ === 'web') {
+    var resizeMethod = null
+    var resizeCallback = function () {
+      var w = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth
+      var h = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight
+      resizeMethod && resizeMethod({ size: { windowWidth: w, windowHeight: h } })
+    }
+    return {
+      activated () {
+        if (this.onResize) {
+          resizeMethod = this.onResize
+          window.addEventListener('resize', resizeCallback, false)
+        }
+      },
+      deactivated () {
+        if (this.onResize) {
+          window.removeEventListener('resize', resizeCallback, false)
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/platform/patch/web/lifecycle.js
+++ b/packages/core/src/platform/patch/web/lifecycle.js
@@ -21,10 +21,10 @@ const PAGE_HOOKS = [
   'onUnload',
   'onPullDownRefresh',
   'onReachBottom',
-  'onPageScroll'
+  'onPageScroll',
   // 'onShareAppMessage',
   // 'onTabItemTap',
-  // 'onResize'
+  'onResize'
 ]
 
 const APP_HOOKS = [


### PR DESCRIPTION
### 小程序输出H5 支持 onResize 事件改动点
* 增加 pageOnResizeMixin
* NOTSUPPORTS 数组中去除 onResize 过滤
* getBuiltInMixins 中增加 onResize 事件
* web lifecycle 中 pagehooks 增加 onResize 事件
