### PR TITLE
remove unsupported api documents

### DIFF
--- a/docs-vuepress/api/global-api.md
+++ b/docs-vuepress/api/global-api.md
@@ -10,7 +10,7 @@ createApp(options)
 - **参数：**
     - `{Object} options`
     
-        可指定小程序的生命周期回调，methods 方法，以及一些全局变量等 
+        可指定小程序的生命周期回调，以及一些全局变量等 
             
 
 - **示例：**
@@ -24,7 +24,6 @@ mpx.createApp({
   onShow () {
     console.log('Page show')
   },
-  methods: {},
   //全局变量 可通过getApp()访问
   globalDataA: 'I am global dataA',
   globalDataB: 'I am global dataB'
@@ -302,7 +301,7 @@ createStoreWithThis(object)
 - **示例：**
 ```js
 
-import {createComponent, getComputed, getMixin, createStoreWithThis} from '@mpxjs/core
+import {createComponent, getMixin, createStoreWithThis} from '@mpxjs/core
 
 const store = createStoreWithThis({
   state: {
@@ -332,9 +331,8 @@ createComponent({
       return this.b
     },
     d() {
-      // 在computed中访问当前computed对象中的其他计算属性时，需要用getComputed辅助函数包裹，
-      // 而除此以外的任何场景下都不需要使用，例如访问data或者mixins中定义的computed等数据
-      return getComputed(this.c) + this.a + this.aaa
+      // data, mixin, computed中定义的数据能够被推导到this中
+      return this.a + this.aaa + this.c
     },
     // 从store上map过来的计算属性或者方法同样能够被推导到this中
     ...store.mapState(['aa'])
@@ -556,34 +554,6 @@ createComponent({
 28
 2 "attached"
 */
-```
-
-## getComputed
-
-- **参数**：
-  - `{Function} computedItem`
-
-- **用法**:
-
-Typescript 类型推导辅助函数。在 computed 中访问当前 computed 对象中的其他计算属性时，需要用 getComputed 辅助函数包裹。
-
-```js
-import {createComponent, getComputed} from '@mpxjs/core'
-
-createComponent({
-  data: {
-    a: 1,
-    b: '2'
-  },
-  computed: {
-    c() {
-      return this.b
-    },
-    d() {
-      return getComputed(this.c) + this.a + this.a
-    },
-  }
-})
 ```
 
 ## implement

--- a/docs-vuepress/guide/tool/ts.md
+++ b/docs-vuepress/guide/tool/ts.md
@@ -109,7 +109,7 @@ mpx.$myProperty = 'my-property'
 Mpx 基于泛型函数提供了非常方便用户使用的反向类型推导能力，简单来说，就是用户可以用非常接近于 js 的方式调用 Mpx 提供的 api ，就能够获得大量基于用户输入参数反向推导得到的类型提示及检查。但是由于 ts 本身的能力限制，我们在 Mpx 的运行时中添加了少量辅助函数和变种api，便于用户最大程度地享受反向类型推导带来的便利性，简单的使用示例如下：
 
 ```typescript
-import {createComponent, getComputed, getMixin, createStoreWithThis} from '@mpxjs/core'
+import {createComponent, getMixin, createStoreWithThis} from '@mpxjs/core'
 
 // createStoreWithThis作为createStore的变种方法，主要变化在于定义getters，mutations和actions时，
 // 获取自身的state，getters等属性不再通过参数传入，而是通过this.state或者this.getters等属性进行访问，
@@ -146,9 +146,8 @@ createComponent({
       return this.b
     },
     d() {
-      // 在computed中访问当前computed对象中的其他计算属性时，需要用getComputed辅助函数包裹，
-      // 而除此以外的任何场景下都不需要使用，例如访问data或者mixins中定义的computed等数据
-      return getComputed(this.c) + this.a + this.aaa
+      // data, mixin, computed中定义的数据能够被推导到this中
+      return this.a + this.aaa + this.c
     },
     // 从store上map过来的计算属性或者方法同样能够被推导到this中
     ...store.mapState(['aa'])
@@ -180,11 +179,6 @@ createComponent({
   }
 })
 ```
-
-### getComputed
-
-todo 描述getComputed的使用方法及含义
-todo 根据肖磊的信息最新版本的ts不再需要该辅助方案，待验证
 
 ### getMixin
 

--- a/docs/ts.md
+++ b/docs/ts.md
@@ -112,7 +112,7 @@ mpx.$myProperty = 'my-property'
 Mpx基于泛型函数提供了非常方便用户使用的反向类型推导能力，简单来说，就是用户可以用非常接近于js的方式调用Mpx提供的api，就能够获得大量基于用户输入参数反向推导得到的类型提示及检查。但是由于ts本身的能力限制，我们在mpx的运行时中添加了少量辅助函数和变种api，便于用户最大程度地享受反向类型推导带来的便利性，具体的注意事项和使用方法如下述demo
 
 ```typescript
-import {createComponent, getComputed, getMixin, createStoreWithThis} from '@mpxjs/core'
+import {createComponent, getMixin, createStoreWithThis} from '@mpxjs/core'
 
 // createStoreWithThis作为createStore的变种方法，主要变化在于定义getters，mutations和actions时，
 // 获取自身的state，getters等属性不再通过参数传入，而是通过this.state或者this.getters等属性进行访问，
@@ -149,9 +149,8 @@ createComponent({
       return this.b
     },
     d() {
-      // 在computed中访问当前computed对象中的其他计算属性时，需要用getComputed辅助函数包裹，
-      // 而除此以外的任何场景下都不需要使用，例如访问data或者mixins中定义的computed等数据
-      return getComputed(this.c) + this.a + this.aaa
+      // data, mixin, computed中定义的数据能够被推导到this中
+      return this.a + this.aaa + this.c
     },
     // 从store上map过来的计算属性或者方法同样能够被推导到this中
     ...store.mapState(['aa'])


### PR DESCRIPTION
- 删除`getComputed`相关文档
- 删除`createApp`文档中`methods`相关描述

上述api最新版中已经删除了, 使用会报错.

- [ ] `packages/webpack-plugin/lib/index.js`文件中, `apiBlackListMap`数组里的`getComputed`, 不知道是否需要删除.