### PR TITLE
修复动态组件循环时多个 wx:if 标签问题

### DIFF
--- a/packages/webpack-plugin/lib/template-compiler/compiler.js
+++ b/packages/webpack-plugin/lib/template-compiler/compiler.js
@@ -980,7 +980,7 @@ function getAndRemoveAttr (el, name, removeFromMap = true) {
 }
 
 function addAttrs (el, attrs) {
-  const list = el.attrsList
+  const list = []
   const map = el.attrsMap
   for (let i = 0, l = attrs.length; i < l; i++) {
     list.push(attrs[i])
@@ -990,6 +990,7 @@ function addAttrs (el, attrs) {
     }
     map[attrs[i].name] = attrs[i].value
   }
+  el.attrsList = el.attrsList.concat(list)
 }
 
 function modifyAttr (el, name, val) {


### PR DESCRIPTION
避免直接通过引用的方式修改attrsList，会影响同层级component attrs