### PR TITLE
fix ref class

### DIFF
--- a/packages/webpack-plugin/lib/template-compiler/compiler.js
+++ b/packages/webpack-plugin/lib/template-compiler/compiler.js
@@ -1724,7 +1724,8 @@ function injectWxs (meta, module, src) {
 
 function processClass (el, meta) {
   const type = 'class'
-  const targetType = el.tag.startsWith('th-') ? 'ex-' + type : type
+  const needEx = el.tag.startsWith('th-')
+  const targetType = needEx ? 'ex-' + type : type
   let dynamicClass = getAndRemoveAttr(el, config[mode].directive.dynamicClass)
   let staticClass = getAndRemoveAttr(el, type)
   if (dynamicClass) {
@@ -1740,6 +1741,17 @@ function processClass (el, meta) {
       name: targetType,
       value: staticClass
     }])
+  }
+
+  if (needEx && staticClass) {
+    const refClassRegExp = /ref_(\w+)_(\d+)/
+    const match = staticClass.match(refClassRegExp)
+    if (match) {
+      addAttrs(el, [{
+        name: 'class',
+        value: match[0]
+      }])
+    }
   }
 }
 


### PR DESCRIPTION
the class indicating a node is set as a ref will be removed when processing class if the component tag starts with 'th-', causing corresponding ref can't be resolved. 
so ref class need to be restored.
在processClass时候，如果当前节点的tag是以th-开头的，class会被移动到ex-class。此时如果当前节点被设置为ref的时候，在组件初始化时候，ref就resolve不到。需要考虑在移动到ex-class之后，判断是否有ref class，有的话，需要恢复ref class