### PR TITLE
feat:根据注释和当前打包平台去掉没有必要的代码

### DIFF
--- a/packages/webpack-plugin/lib/selector.js
+++ b/packages/webpack-plugin/lib/selector.js
@@ -13,6 +13,25 @@ module.exports = function (content) {
   const defs = mpx.defs
   const query = loaderUtils.getOptions(this) || {}
   const filePath = this.resourcePath
+  if (mpx.loaderOptions.useStripCode) {
+    const startComment = `@${mpx.loaderOptions.useStripCode.startComment || '@if'} `
+    // 这个应该要移出去写在枚举文件里面
+    const modes = ['wx', 'ali', 'swan', 'qq', 'tt']
+    const useMode = modes.reduce((cur, sum) => {
+      return sum + '|' + cur
+    })
+    const endComment = `@${mpx.loaderOptions.useStripCode.endComment || '@endif'}`
+    const exp = '[\\t ]*\\/\\* ?' + startComment + '(' + useMode + ')' + ' ?\\*\\/[\\s\\S]*?\\/\\* ?' + endComment + ' ?\\*\\/[\\t ]*\\n?'
+    const regexPattern = new RegExp(exp, 'g')
+    content = content.replace(regexPattern, function (match) {
+      const matchMode = arguments[1]
+      if (matchMode === mpx.mode) {
+        return match
+      } else {
+        return ''
+      }
+    })
+  }
   const parts = parseComponent(content, {
     filePath,
     needMap: this.sourceMap,


### PR DESCRIPTION
主要解决包体积过大的问题。根据注释条件 有些没有意义的其他平台的代码直接去掉（包括特有平台的包）

目前需要在`config`中的`mpxLoader.confg.js`配置
```js
{
  useStripCode:{
   startComment:  '',  // 默认是 @if
   endComment:  ''  // 默认@endif
  }
}
```
例如
```js
  methods:{
  /*  @if ali */
   log() {
     console.log('log')
   }
   /* @endif */
}
```
在打包的时候，只有在`ali`这种mode下，这行代码才会被打入进去，如果在`wx`这种mode下，这行代码直接无了。
---
### Todo
1. 支持更多的注释形式 目前只支持 `/* */ ` 。将要扩展到其他注释形式。例如 `//` `<-- -->`。
2. 扩展其他文件。目前简单支持了js。
3. 补充对应的文档。
### 疑惑
1. 不太清楚是不是还有更好处理这些不要的代码的生命周期？ 我是觉得放在loader处理代码之前比较好。目前看来就是这个文件处理是最早的。
2. 是不是该放在production模式下？跑了测试下，如果项目不大，对于编译速度其实影响不大，如果项目过大，不清楚对于项目的编译影响多大。
3. 是不是需要扩展支持 多平台的支持。例如`wx|ali`，或者全平台都去掉`all` 。