### PR TITLE
fix promisify

### DIFF
--- a/packages/api-proxy/src/mini/promisify.js
+++ b/packages/api-proxy/src/mini/promisify.js
@@ -26,6 +26,10 @@ const blackList = [
   'getMenuButtonBoundingClientRect'
 ]
 
+if (__mpx_mode__ !== 'ali') {
+  blackList.push('uploadFile', 'downloadFile')
+}
+
 function getMapFromList (list) {
   if (list && list.length) {
     const map = {}

--- a/packages/api-proxy/src/mini/promisify.js
+++ b/packages/api-proxy/src/mini/promisify.js
@@ -23,12 +23,10 @@ const blackList = [
   'createWorker',
   'pageScrollTo',
   'reportAnalytics',
-  'getMenuButtonBoundingClientRect'
+  'getMenuButtonBoundingClientRect',
+  'uploadFile',
+  'downloadFile'
 ]
-
-if (__mpx_mode__ !== 'ali') {
-  blackList.push('uploadFile', 'downloadFile')
-}
 
 function getMapFromList (list) {
   if (list && list.length) {


### PR DESCRIPTION
解决 issue：https://github.com/didi/mpx/issues/695

测试了下，除支付宝小程序外，其他如微信、百度、头条小程序的 uploadFile 和 downloadFile 的返回值类型都不是 Promise。