### PR TITLE
添加reportMonitor api 到blackList 中不走 promiseify

### DIFF
--- a/packages/api-proxy/src/mini/promisify.js
+++ b/packages/api-proxy/src/mini/promisify.js
@@ -23,7 +23,8 @@ const blackList = [
   'createWorker',
   'pageScrollTo',
   'reportAnalytics',
-  'getMenuButtonBoundingClientRect'
+  'getMenuButtonBoundingClientRect',
+  'reportMonitor'
 ]
 
 function getMapFromList (list) {


### PR DESCRIPTION
添加reportMonitor api 到blackList 中不走 promiseify