### PR TITLE
Update core define

### DIFF
--- a/packages/core/@types/index.d.ts
+++ b/packages/core/@types/index.d.ts
@@ -276,16 +276,17 @@ export function createMutationsWithThis<S = {}, D extends Deps = {}, M extends M
   deps?: D
 }): M
 
-export function createActionsWithThis<S = {}, G = {}, M extends MutationsAndActionsWithThis = {}, D extends Deps = {}, A extends MutationsAndActionsWithThis = {}> (actions: A & ThisType<{
+export function createActionsWithThis<S = {}, G = {}, M extends MutationsAndActionsWithThis = {}, D extends Deps = {}, A extends MutationsAndActionsWithThis = {}, OA extends MutationsAndActionsWithThis = {}> (actions: A & ThisType<{
   rootState: any,
   state: S & UnboxDepsField<D, 'state'>,
   getters: GetComputedType<G> & UnboxDepsField<D, 'getters'>,
-  dispatch: GetDispatchAndCommitWithThis<A, D, 'actions'>,
+  dispatch: GetDispatchAndCommitWithThis<A & OA, D, 'actions'>,
   commit: GetDispatchAndCommitWithThis<M, D, 'mutations'>
 } & MpxStore.CompatibleDispatch>, options?: {
   state?: S,
   getters?: G,
   mutations?: M,
+  actions?: OA,
   deps?: D
 }): A
 

--- a/packages/core/@types/mpx-store.d.ts
+++ b/packages/core/@types/mpx-store.d.ts
@@ -127,9 +127,22 @@ declare namespace MpxStore {
     [key: string]: any | DeeperStateAndGetters
   }
 
+  /**
+   * remove compatible code in Mpx.
+   * if you need using createStoreWithThis mix with createStore
+   * you can add a global define file
+   * use Declaration Merging(https://www.typescriptlang.org/docs/handbook/declaration-merging.html) on CompatibleDispatch:
+   * @example
+   * declare module MpxStore {
+   *  interface CompatibleDispatch {
+   *    dispatch(type: string, ...payload: any[]): any
+   *    commit(type: string, ...payload: any[]): any
+   *  }
+   * }
+   */
   interface CompatibleDispatch {
-    dispatch(type: string, ...payload: any[]): any
-    commit(type: string, ...payload: any[]): any
+    // dispatch(type: string, ...payload: any[]): any
+    // commit(type: string, ...payload: any[]): any
   }
 
   // Store Type Bindings


### PR DESCRIPTION
`createActionsWithThis` 增加 actions 依赖，使拆分 actions 更加便捷。

删除 `CompatibleDispatch` 中的兼容代码，后续不再在框架层面主动兼容 `createStoreWithThis` 和 `createStore`，如果用户需要，可自行对 `CompatibleDispatch` 作声明合并操作。

例：

```ts
declare module MpxStore {
  interface CompatibleDispatch {
    dispatch(type: string, ...payload: any[]): any
    commit(type: string, ...payload: any[]): any
  }
}
```

声明合并： https://www.tslang.cn/docs/handbook/declaration-merging.html

Declaration Merging： https://www.typescriptlang.org/docs/handbook/declaration-merging.html
