### PR TITLE
ActionSheet.styl  间距

### DIFF
--- a/packages/api-proxy/src/common/stylus/ActionSheet.styl
+++ b/packages/api-proxy/src/common/stylus/ActionSheet.styl
@@ -1,5 +1,5 @@
 .__mpx_actionsheet__
-    display none
+  display none
   &.show
     display block
   .__mpx_mask__


### PR DESCRIPTION
ActionSheet.styl 间距错误，导致stylus解析错误
解析错误示例
```css
.__mpx_actionsheet__{
   display:none;
}
    
 .show{
   display:block;
}
```

应该是

```css
.__mpx_actionsheet__{
   display:none;
}
    
.__mpx_actionsheet__.show{
   display:block;
}
```
