### PR TITLE
feat: support rpx style when transfer to web

### DIFF
--- a/packages/webpack-plugin/lib/loader.js
+++ b/packages/webpack-plugin/lib/loader.js
@@ -179,7 +179,7 @@ module.exports = function (content) {
           if (typeof val === 'string' && val.indexOf('rpx') > 0) {
             return val.replace(rpxRegExpG, function (match, $1) {
               return '' + ($1 * rpx2vwRatio) + 'vw'
-            })
+            }).replace(/"/g,"")
           }
 
           return val

--- a/packages/webpack-plugin/lib/loader.js
+++ b/packages/webpack-plugin/lib/loader.js
@@ -170,6 +170,34 @@ module.exports = function (content) {
           output += `
       import App from ${stringifyRequest(request)}
       import Vue from 'vue'
+
+      Vue.filter('parseRpxStyle', function (style) {
+        const rpxRegExpG = /\\b(\\d+(\\.\\d+)?)\\s*rpx\\b/g
+        const rpx2vwRatio = +(100 / 750).toFixed(8)
+
+        function parseValue(val) {
+          if (typeof val === 'string' && val.indexOf('rpx') > 0) {
+            return val.replace(rpxRegExpG, function (match, $1) {
+              return '' + ($1 * rpx2vwRatio) + 'vw'
+            })
+          }
+
+          return val
+        }
+
+        if (typeof style === 'string') {
+          return parseValue(style)
+        }
+
+        if (typeof style === 'object') {
+          Object.keys(style).forEach(key => {
+            style[key] = parseValue(style[key])
+          })
+        }
+
+        return style
+      })
+
       new Vue({
         el: '#app',
         render: function(h){

--- a/packages/webpack-plugin/lib/platform/template/wx/index.js
+++ b/packages/webpack-plugin/lib/platform/template/wx/index.js
@@ -16,7 +16,7 @@ function parseRpxStyle (style) {
     if (typeof val === 'string' && val.indexOf('rpx') > 0) {
       return val.replace(rpxRegExpG, function (match, $1) {
         return `${$1 * rpx2vwRatio}vw`
-      })
+      }).replace(/"/g,"")
     }
 
     return val

--- a/packages/webpack-plugin/lib/platform/template/wx/index.js
+++ b/packages/webpack-plugin/lib/platform/template/wx/index.js
@@ -54,7 +54,7 @@ module.exports = function getSpec ({ warn, error }) {
               }
             } else if (parsed.hasBinding) {
               return {
-                name: 'style',
+                name: ':style',
                 value: `(${parsed.result}) | parseRpxStyle`
               }
             }


### PR DESCRIPTION
支持 wx 转换成 web 时，style 使用 rpx 单位
支持使用方式如下

```
<view style="width:100rpx;"></view>
<view style="{{style}}"></view>
<view wx:style="{{ {fontSize:'16rpx', fontWeight:'bold'} }}" ></view>
<view wx:style="width:100rpx;"></view>
<view wx:style="{{style}}"></view>
<view wx:style="{{style}}width:100rpx;"></view>
```

副作用：
全局注入  parseRpxStyle filter
