### PR TITLE
feat(size-report):将产物中的绝对路径变为相对路径

### DIFF
--- a/packages/size-report/src/SizeReportPlugin.js
+++ b/packages/size-report/src/SizeReportPlugin.js
@@ -34,6 +34,10 @@ class SizeReportPlugin {
       })
     })
 
+    function getRelativePathToProject(resourcePath){
+      return './' + path.posix.relative(compiler.context, resourcePath)
+    }
+
     compiler.hooks.thisCompilation.tap('SizeReportPlugin', (compilation) => {
       compilation.hooks.assetPath.tap('SizeReportPlugin', (path, data, assetInfo) => {
         if (data.chunk && assetInfo) {
@@ -352,7 +356,7 @@ class SizeReportPlugin {
         for (let resourcePath in resourcePathMap) {
           const redundantSize = resourcePathMap[resourcePath].redundantSize
           const sizeInfoItem = {
-            resourcePath,
+            resourcePath: getRelativePathToProject(resourcePath),
             redundantSize: redundantSize,
             packages: resourcePathMap[resourcePath].packages
             // modules: resourcePathMap[resourcePath].modules
@@ -418,7 +422,7 @@ class SizeReportPlugin {
             if (_entryModules) {
               _entryModules.forEach((entryModule) => {
                 entryModules.add(entryModule)
-                entryModulePathSet.add(parseRequest(entryModule.resource).resourcePath)
+                entryModulePathSet.add(getRelativePathToProject(parseRequest(entryModule.resource).resourcePath))
               })
             }
             if (_noEntryModules) {
@@ -506,7 +510,7 @@ class SizeReportPlugin {
             const entryModulePathSet = new Set()
 
             entryModules.forEach((module) => {
-              entryModulePathSet.add(parseRequest(module.resource).resourcePath)
+              entryModulePathSet.add(getRelativePathToProject(parseRequest(module.resource).resourcePath))
             })
             fillSizeReportGroups(entryModules, noEntryModules, packageName, 'modules', {
               name,


### PR DESCRIPTION
目前产出的 assetsSizeInfo 和 redundanceSizeInfo 都是以绝对路径开头，例如
```json
"entryModulePaths": [
  "/Users/xxx/Desktop/project/WebApp/mp-apphome/src/app.mpx",
  "/Users/xxx/Desktop/project/WebApp/mp-apphome/src/pages/index/xxx.mpx",
  "/Users/xxx/Desktop/project/WebApp/mp-apphome/src/pages/index/xxx1.mpx",
  "/Users/xxx/Desktop/project/WebApp/mp-apphome/src/pages/index/xxx2.mpx",
]
```
这似乎并没有什么用，我们只需要关注其相对于项目根路径的相对路径即可，所以我认为应该去掉这些绝对路径，使他们变得简洁。
```json
"entryModulePaths": [
  "./src/app.mpx",
  "./src/pages/index/xxx.mpx",
  "./src/pages/index/xxx1.mpx",
  "./src/pages/index/xxx2.mpx",
]
```