### PR TITLE
修复输出H5 wx:class不生效问题

### DIFF
--- a/docs-vuepress/api/directives.md
+++ b/docs-vuepress/api/directives.md
@@ -279,7 +279,7 @@
   我们可以把一个数组传给 `wx:class`，以应用一个 class 列表：
 
   ``` html
-  <view wx:class="[{{activeClass}},{{errorClass}}]">
+  <view wx:class="{{[activeClass, errorClass]}}">
     这是一段测试文字
   </view>
   ```
@@ -345,9 +345,11 @@
     import {createComponent} from '@mpxjs/core'
 
     createComponent({
-      styleObject: {
-        color: 'red',
-        fontWeight: 'bold'
+      data: {
+        styleObject: {
+          color: 'red',
+          fontWeight: 'bold'
+        }
       },
     })
   </script>
@@ -388,7 +390,7 @@
   `wx:style` 的数组语法可以将多个样式对象应用到同一个元素上
 
   ``` html
-  <view wx:style="[baseStyles, overridingStyles]">
+  <view wx:style="{{[baseStyles, overridingStyles]}}">
     这是一段测试文字
   </view>
   ```

--- a/packages/webpack-plugin/lib/platform/template/wx/index.js
+++ b/packages/webpack-plugin/lib/platform/template/wx/index.js
@@ -210,7 +210,7 @@ module.exports = function getSpec ({ warn, error }) {
       },
       {
         // 样式类名绑定
-        test: /^wx:class$/,
+        test: /^wx:(class)$/,
         web ({ name, value }) {
           const dir = this.test.exec(name)[1]
           const parsed = parseMustache(value)

--- a/packages/webpack-plugin/lib/platform/template/wx/index.js
+++ b/packages/webpack-plugin/lib/platform/template/wx/index.js
@@ -211,11 +211,10 @@ module.exports = function getSpec ({ warn, error }) {
       {
         // 样式类名绑定
         test: /^wx:(class)$/,
-        web ({ name, value }) {
-          const dir = this.test.exec(name)[1]
+        web ({ value }) {
           const parsed = parseMustache(value)
           return {
-            name: ':' + dir,
+            name: ':class',
             value: parsed.result
           }
         }


### PR DESCRIPTION
* 修复输出H5 wx:class不生效问题
* 修改文档中关于wx:class 和 wx:style 的数组使用示例