### PR TITLE
processAliStyleClassHack添加srcMode和mode同为ali时的判断,避免引用xx.ali.mpx文件时无事件代理

### DIFF
--- a/packages/webpack-plugin/lib/template-compiler/compiler.js
+++ b/packages/webpack-plugin/lib/template-compiler/compiler.js
@@ -2094,7 +2094,7 @@ function processElement (el, root, options, meta) {
     processShow(el, options, root)
   }
 
-  if (transAli) {
+  if (transAli || (srcMode === 'ali' && mode === 'ali')) {
     processAliStyleClassHack(el, options, root)
     processAliEventHack(el, options, root)
   }


### PR DESCRIPTION
processAliStyleClassHack添加srcMode和mode同为ali时的判断,避免引用xx.ali.mpx文件时无事件代理