### PR TITLE
优化未使用组件检查checkUsingComponents

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -147,7 +147,7 @@ class MpxWebpackPlugin {
     options.auditResource = options.auditResource || false
     options.decodeHTMLText = options.decodeHTMLText || false
     options.i18n = options.i18n || null
-    options.checkUsingComponents = options.checkUsingComponents || false
+    options.checkUsingComponentsRules = options.checkUsingComponentsRules || (options.checkUsingComponents ? { include: () => true } : { exclude: () => true })
     options.reportSize = options.reportSize || null
     options.pathHashMode = options.pathHashMode || 'absolute'
     options.forceDisableBuiltInLoader = options.forceDisableBuiltInLoader || false
@@ -566,7 +566,7 @@ class MpxWebpackPlugin {
           tabBarMap: {},
           defs: preProcessDefs(this.options.defs),
           i18n: this.options.i18n,
-          checkUsingComponents: this.options.checkUsingComponents,
+          checkUsingComponentsRules: this.options.checkUsingComponentsRules,
           forceDisableBuiltInLoader: this.options.forceDisableBuiltInLoader,
           appTitle: 'Mpx homepage',
           attributes: this.options.attributes,

--- a/packages/webpack-plugin/lib/loader.js
+++ b/packages/webpack-plugin/lib/loader.js
@@ -100,6 +100,7 @@ module.exports = function (content) {
       const isNative = false
 
       let usingComponents = [].concat(Object.keys(mpx.usingComponents))
+      let componentPlaceholder = []
 
       let componentGenerics = {}
 
@@ -109,6 +110,9 @@ module.exports = function (content) {
           if (ret.usingComponents) {
             fixUsingComponent(ret.usingComponents, mode)
             usingComponents = usingComponents.concat(Object.keys(ret.usingComponents))
+          }
+          if (ret.componentPlaceholder) {
+            componentPlaceholder = componentPlaceholder.concat(Object.values(ret.componentPlaceholder))
           }
           if (ret.componentGenerics) {
             componentGenerics = Object.assign({}, ret.componentGenerics)
@@ -279,7 +283,8 @@ module.exports = function (content) {
           hasComment,
           isNative,
           moduleId,
-          usingComponents
+          usingComponents,
+          componentPlaceholder
           // 添加babel处理渲染函数中可能包含的...展开运算符
           // 由于...运算符应用范围极小以及babel成本极高，先关闭此特性后续看情况打开
           // needBabel: true

--- a/packages/webpack-plugin/lib/template-compiler/compiler.js
+++ b/packages/webpack-plugin/lib/template-compiler/compiler.js
@@ -836,9 +836,15 @@ function parse (template, options) {
   })
 
   if (!tagNames.has('component')) {
-    options.usingComponents.forEach((item) => {
-      if (!tagNames.has(item) && !options.globalComponents.includes(item) && options.checkUsingComponents) warn$1(`${item}注册了，但是未被对应的模板引用，建议删除！`)
-    })
+    if (options.checkUsingComponents) {
+      const arr = []
+      options.usingComponents.forEach((item) => {
+        if (!tagNames.has(item) && !options.globalComponents.includes(item) && !options.componentPlaceholder.includes(item)) {
+          arr.push(item)
+        }
+      })
+      arr.length && warn$1(`\n ${options.filePath} \n 组件 ${arr.join(' | ')} 注册了，但是未被对应的模板引用，建议删除！`)
+    }
   }
 
   return {

--- a/packages/webpack-plugin/lib/template-compiler/compiler.js
+++ b/packages/webpack-plugin/lib/template-compiler/compiler.js
@@ -835,16 +835,14 @@ function parse (template, options) {
     Array.isArray(val.errorArray) && val.errorArray.forEach(item => error$1(item))
   })
 
-  if (!tagNames.has('component')) {
-    if (options.checkUsingComponents) {
-      const arr = []
-      options.usingComponents.forEach((item) => {
-        if (!tagNames.has(item) && !options.globalComponents.includes(item) && !options.componentPlaceholder.includes(item)) {
-          arr.push(item)
-        }
-      })
-      arr.length && warn$1(`\n ${options.filePath} \n 组件 ${arr.join(' | ')} 注册了，但是未被对应的模板引用，建议删除！`)
-    }
+  if (!tagNames.has('component') && options.checkUsingComponents) {
+    const arr = []
+    options.usingComponents.forEach((item) => {
+      if (!tagNames.has(item) && !options.globalComponents.includes(item) && !options.componentPlaceholder.includes(item)) {
+        arr.push(item)
+      }
+    })
+    arr.length && warn$1(`\n ${options.filePath} \n 组件 ${arr.join(' | ')} 注册了，但是未被对应的模板引用，建议删除！`)
   }
 
   return {

--- a/packages/webpack-plugin/lib/template-compiler/index.js
+++ b/packages/webpack-plugin/lib/template-compiler/index.js
@@ -21,6 +21,7 @@ module.exports = function (raw) {
   const componentsMap = mpx.componentsMap[packageName]
   const wxsContentMap = mpx.wxsContentMap
   const usingComponents = queryObj.usingComponents || []
+  const componentPlaceholder = queryObj.componentPlaceholder || []
   const hasComment = queryObj.hasComment
   const isNative = queryObj.isNative
   const hasScoped = queryObj.hasScoped
@@ -42,6 +43,7 @@ module.exports = function (raw) {
     warn,
     error,
     usingComponents,
+    componentPlaceholder,
     hasComment,
     isNative,
     isComponent: !!componentsMap[resourcePath],
@@ -56,7 +58,7 @@ module.exports = function (raw) {
     // 这里需传递resourcePath和wxsContentMap保持一致
     filePath: resourcePath,
     i18n,
-    checkUsingComponents: mpx.checkUsingComponents,
+    checkUsingComponents: matchCondition(resourcePath, mpx.checkUsingComponentsRules),
     globalComponents: Object.keys(mpx.usingComponents),
     forceProxyEvent: matchCondition(resourcePath, mpx.forceProxyEventRules),
     hasVirtualHost: matchCondition(resourcePath, mpx.autoVirtualHostRules)


### PR DESCRIPTION
1. 新增checkUsingComponentsRules控制检查范围，兼容以前checkUsingComponents的配置
2. 当组件在componentPlaceholder作为占位组件时，判定为已使用
3. 合并页面未使用组件，带上path一起输出（方便定位）