### PR TITLE
move import 时处理有注释情况的end loc时多加了startIndex

### DIFF
--- a/packages/webpack-plugin/lib/script-setup-compiler/index.js
+++ b/packages/webpack-plugin/lib/script-setup-compiler/index.js
@@ -361,7 +361,7 @@ function compileScriptSetup (
     if (node.trailingComments && node.trailingComments.length > 0) {
       const lastCommentNode =
         node.trailingComments[node.trailingComments.length - 1]
-      end = lastCommentNode.end + startOffset
+      end = lastCommentNode.end
     }
 
     // locate the end of whitespace between this statement and the next


### PR DESCRIPTION
修复 script setup move import 时注释的场景下，end loc计算不准确问题