### PR TITLE
fix: reactive set相同值badcase -0 & 0

### DIFF
--- a/packages/core/src/observer/reactive.js
+++ b/packages/core/src/observer/reactive.js
@@ -9,7 +9,8 @@ import {
   hasProto,
   def,
   isValidArrayIndex,
-  arrayProtoAugment
+  arrayProtoAugment,
+  hasChanged
 } from '@mpxjs/utils'
 
 const arrayKeys = Object.getOwnPropertyNames(arrayMethods)
@@ -139,7 +140,7 @@ export function defineReactive (obj, key, val, shallow) {
     set: function reactiveSetter (newVal) {
       const value = getter ? getter.call(obj) : val
       /* eslint-disable no-self-compare */
-      if (!(shallow && isForceTrigger) && (newVal === value || (newVal !== newVal && value !== value))) {
+      if (!(shallow && isForceTrigger) && (!hasChanged(newVal, value) || (newVal !== newVal && value !== value))) {
         return
       }
       if (!shallow && isRef(value) && !isRef(newVal)) {

--- a/packages/core/src/observer/reactive.js
+++ b/packages/core/src/observer/reactive.js
@@ -139,8 +139,7 @@ export function defineReactive (obj, key, val, shallow) {
     },
     set: function reactiveSetter (newVal) {
       const value = getter ? getter.call(obj) : val
-      /* eslint-disable no-self-compare */
-      if (!(shallow && isForceTrigger) && (!hasChanged(newVal, value) || (newVal !== newVal && value !== value))) {
+      if (!(shallow && isForceTrigger) && !hasChanged(newVal, value)) {
         return
       }
       if (!shallow && isRef(value) && !isRef(newVal)) {

--- a/packages/core/src/observer/watch.js
+++ b/packages/core/src/observer/watch.js
@@ -11,7 +11,8 @@ import {
   warn,
   isArray,
   remove,
-  callWithErrorHandling
+  callWithErrorHandling,
+  hasChanged
 } from '@mpxjs/utils'
 
 export function watchEffect (effect, options) {
@@ -30,7 +31,7 @@ const warnInvalidSource = (s) => {
   warn(`Invalid watch source: ${s}\nA watch source can only be a getter/effect function, a ref, a reactive object, or an array of these types.`)
 }
 
-const shouldTrigger = (value, oldValue) => !Object.is(value, oldValue) || isObject(value)
+const shouldTrigger = (value, oldValue) => hasChanged(value, oldValue) || isObject(value)
 
 const processWatchOptionsCompat = (options) => {
   const newOptions = { ...options }

--- a/packages/utils/src/base.js
+++ b/packages/utils/src/base.js
@@ -89,6 +89,11 @@ function aliasReplace (options = {}, alias, target) {
   return options
 }
 
+// 比较一个值是否发生了变化（考虑NaN）。
+function hasChanged (value, oldValue) {
+  return !Object.is(value, oldValue)
+}
+
 export {
   hasProto,
   noop,
@@ -106,5 +111,6 @@ export {
   aliasReplace,
   dash2hump,
   hump2dash,
-  def
+  def,
+  hasChanged
 }


### PR DESCRIPTION
```js
it.only('ref', () => {
  const a = ref(0)
  const b = computed(() => {
    return a.value
  })
  a.value = -0
  expect(b.value).toBe(-0)
})
```

如上述test， 期望`a.value`改为`-0`时，computed`b`的`value`也响应变化，现状未变化。