### PR TITLE
Fix ts loader watch run error

### DIFF
--- a/packages/webpack-plugin/lib/loader.js
+++ b/packages/webpack-plugin/lib/loader.js
@@ -18,6 +18,7 @@ const AppEntryDependency = require('./dependencies/AppEntryDependency')
 const RecordResourceMapDependency = require('./dependencies/RecordResourceMapDependency')
 const RecordVueContentDependency = require('./dependencies/RecordVueContentDependency')
 const CommonJsVariableDependency = require('./dependencies/CommonJsVariableDependency')
+const tsWatchRunLoaderFilter = require('./utils/ts-loader-watch-run-loader-filter')
 const { MPX_APP_MODULE_ID } = require('./utils/const')
 const path = require('path')
 
@@ -26,7 +27,7 @@ module.exports = function (content) {
 
   // 兼容处理处理ts-loader中watch-run/updateFile逻辑，直接跳过当前loader及后续的vue-loader返回内容
   if (path.extname(this.resourcePath) === '.ts') {
-    this.loaderIndex -= 2
+    this.loaderIndex = tsWatchRunLoaderFilter(this.loaders, this.loaderIndex)
     return content
   }
 

--- a/packages/webpack-plugin/lib/loader.js
+++ b/packages/webpack-plugin/lib/loader.js
@@ -25,8 +25,9 @@ const path = require('path')
 module.exports = function (content) {
   this.cacheable()
 
-  // 兼容处理处理ts-loader中watch-run/updateFile逻辑，直接跳过当前loader及后续的vue-loader返回内容
-  if (path.extname(this.resourcePath) === '.ts') {
+  // 兼容处理处理ts-loader中watch-run/updateFile逻辑，直接跳过当前loader及后续的loader返回内容
+  const pathExtname = path.extname(this.resourcePath)
+  if (!['.vue', '.mpx'].includes(pathExtname)) {
     this.loaderIndex = tsWatchRunLoaderFilter(this.loaders, this.loaderIndex)
     return content
   }

--- a/packages/webpack-plugin/lib/selector.js
+++ b/packages/webpack-plugin/lib/selector.js
@@ -5,7 +5,9 @@ const tsWatchRunLoaderFilter = require('./utils/ts-loader-watch-run-loader-filte
 
 module.exports = function (content) {
   this.cacheable()
-  if (path.extname(this.resourcePath) === '.ts') {
+  // 兼容处理处理ts-loader中watch-run/updateFile逻辑，直接跳过当前loader及后续的loader返回内容
+  const pathExtname = path.extname(this.resourcePath)
+  if (!['.vue', '.mpx'].includes(pathExtname)) {
     this.loaderIndex = tsWatchRunLoaderFilter(this.loaders, this.loaderIndex)
     return content
   }

--- a/packages/webpack-plugin/lib/selector.js
+++ b/packages/webpack-plugin/lib/selector.js
@@ -1,9 +1,14 @@
+const path = require('path')
 const parseComponent = require('./parser')
 const parseRequest = require('./utils/parse-request')
+const tsWatchRunLoaderFilter = require('./utils/ts-loader-watch-run-loader-filter')
 
 module.exports = function (content) {
   this.cacheable()
-
+  if (path.extname(this.resourcePath) === '.ts') {
+    this.loaderIndex = tsWatchRunLoaderFilter(this.loaders, this.loaderIndex)
+    return content
+  }
   // 移除mpx访问依赖，支持 thread-loader
   const { mode, env } = this.getOptions() || {}
   if (!mode && !env) {

--- a/packages/webpack-plugin/lib/utils/get-entry-name.js
+++ b/packages/webpack-plugin/lib/utils/get-entry-name.js
@@ -4,7 +4,7 @@ module.exports = function (loaderContext) {
   let entryName = ''
   for (const [name, { dependencies }] of loaderContext._compilation.entries) {
     const entryModule = moduleGraph.getModule(dependencies[0])
-    if (entryModule.resource === loaderContext.resource) {
+    if (entryModule && entryModule.resource === loaderContext.resource) {
       entryName = name
       break
     }

--- a/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
+++ b/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
@@ -8,16 +8,17 @@ const tsLoaderWatchRunFilterLoaders = [
   scriptSetupPath
 ]
 
-module.exports = (loaders) => {
+module.exports = (loaders, loaderIndex) => {
   let loaderLen = loaders.length
   while (loaderLen > 0) {
-    const currentLoader = this.loaders[loaderLen - 1]
+    const currentLoader = loaders[loaderLen - 1]
     if (!has(tsLoaderWatchRunFilterLoaders, (filterLoaderPath) => {
       return currentLoader.path.endsWith(filterLoaderPath)
     })) {
       break
     }
     loaderLen -= 1
-    this.loaderIndex -= 1
+    loaderIndex -= 1
   }
+  return loaderIndex
 }

--- a/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
+++ b/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
@@ -1,0 +1,23 @@
+const normalize = require('./normalize')
+const selectorPath = normalize.lib('selector.js')
+const scriptSetupPath = normalize.lib('script-setup-compiler/index.js')
+const { has } = require('./set')
+
+const tsLoaderWatchRunFilterLoaders = [
+  selectorPath,
+  scriptSetupPath
+]
+
+module.exports = (loaders) => {
+  let loaderLen = loaders.length
+  while (loaderLen > 0) {
+    const currentLoader = this.loaders[loaderLen - 1]
+    if (!has(tsLoaderWatchRunFilterLoaders, (filterLoaderPath) => {
+      return currentLoader.path.endsWith(filterLoaderPath)
+    })) {
+      break
+    }
+    loaderLen -= 1
+    this.loaderIndex -= 1
+  }
+}

--- a/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
+++ b/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
@@ -4,22 +4,20 @@ const scriptSetupPath = normalize.lib('script-setup-compiler/index.js')
 const mpxLoaderPath = normalize.lib('loader.js')
 const { has } = require('./set')
 
-const tsLoaderWatchRunFilterLoaders = [
+const tsLoaderWatchRunFilterLoaders = new Set([
   selectorPath,
   scriptSetupPath,
   mpxLoaderPath,
   'node_modules/vue-loader/lib/index.js'
-]
+])
 
 module.exports = (loaders, loaderIndex) => {
   for (let len = loaders.length; len > 0; --len) {
     const currentLoader = loaders[len - 1]
-    if (!has(tsLoaderWatchRunFilterLoaders, (filterLoaderPath) => {
-      return currentLoader.path.endsWith(filterLoaderPath)
-    })) {
+    if (!has(tsLoaderWatchRunFilterLoaders, filterLoaderPath => currentLoader.path.endsWith(filterLoaderPath))) {
       break
     }
-    loaderIndex -= 1
+    loaderIndex--
   }
   return loaderIndex
 }

--- a/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
+++ b/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
@@ -1,11 +1,13 @@
 const normalize = require('./normalize')
 const selectorPath = normalize.lib('selector.js')
 const scriptSetupPath = normalize.lib('script-setup-compiler/index.js')
+const mpxLoaderPath = normalize.lib('loader.js')
 const { has } = require('./set')
 
 const tsLoaderWatchRunFilterLoaders = [
   selectorPath,
   scriptSetupPath,
+  mpxLoaderPath,
   'node_modules/vue-loader/lib/index.js'
 ]
 

--- a/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
+++ b/packages/webpack-plugin/lib/utils/ts-loader-watch-run-loader-filter.js
@@ -5,19 +5,18 @@ const { has } = require('./set')
 
 const tsLoaderWatchRunFilterLoaders = [
   selectorPath,
-  scriptSetupPath
+  scriptSetupPath,
+  'node_modules/vue-loader/lib/index.js'
 ]
 
 module.exports = (loaders, loaderIndex) => {
-  let loaderLen = loaders.length
-  while (loaderLen > 0) {
-    const currentLoader = loaders[loaderLen - 1]
+  for (let len = loaders.length; len > 0; --len) {
+    const currentLoader = loaders[len - 1]
     if (!has(tsLoaderWatchRunFilterLoaders, (filterLoaderPath) => {
       return currentLoader.path.endsWith(filterLoaderPath)
     })) {
       break
     }
-    loaderLen -= 1
     loaderIndex -= 1
   }
   return loaderIndex


### PR DESCRIPTION
*  兼容处理处理ts-loader中watch-run/updateFile逻辑，直接跳过所有Mpx文件相关loader
*  兼容处理某个entry未被任何模块引用时，get-entry-module方法中entryModule为空的场景