### PR TITLE
[Fix]worker compile error and persist cache

### DIFF
--- a/packages/webpack-plugin/lib/dependencies/RecordRawContentDependency.js
+++ b/packages/webpack-plugin/lib/dependencies/RecordRawContentDependency.js
@@ -1,0 +1,43 @@
+const NullDependency = require('webpack/lib/dependencies/NullDependency')
+const makeSerializable = require('webpack/lib/util/makeSerializable')
+
+class RecordRawContentDependency extends NullDependency {
+  constructor (resourcePath, content) {
+    super()
+    this.resourcePath = resourcePath
+    this.content = content
+  }
+
+  get type () {
+    return 'mpx record raw content'
+  }
+
+  mpxAction (module, compilation, callback) {
+    const mpx = compilation.__mpx__
+    mpx.rawContent.set(this.resourcePath, this.content)
+    return callback()
+  }
+
+  serialize (context) {
+    const { write } = context
+    write(this.resourcePath)
+    write(this.content)
+    super.serialize(context)
+  }
+
+  deserialize (context) {
+    const { read } = context
+    this.resourcePath = read()
+    this.content = read()
+    super.deserialize(context)
+  }
+}
+
+RecordRawContentDependency.Template = class RecordRawContentDependencyTemplate {
+  apply () {
+  }
+}
+
+makeSerializable(RecordRawContentDependency, '@mpxjs/webpack-plugin/lib/dependencies/RecordRawContentDependency')
+
+module.exports = RecordRawContentDependency

--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -37,6 +37,7 @@ const DynamicEntryDependency = require('./dependencies/DynamicEntryDependency')
 const FlagPluginDependency = require('./dependencies/FlagPluginDependency')
 const RemoveEntryDependency = require('./dependencies/RemoveEntryDependency')
 const RecordVueContentDependency = require('./dependencies/RecordVueContentDependency')
+const RecordRawContentDependency = require('./dependencies/RecordRawContentDependency')
 const SplitChunksPlugin = require('webpack/lib/optimize/SplitChunksPlugin')
 const PartialCompilePlugin = require('./partial-compile/index')
 const fixRelative = require('./utils/fix-relative')
@@ -505,6 +506,9 @@ class MpxWebpackPlugin {
 
       compilation.dependencyFactories.set(RecordVueContentDependency, new NullFactory())
       compilation.dependencyTemplates.set(RecordVueContentDependency, new RecordVueContentDependency.Template())
+
+      compilation.dependencyFactories.set(RecordRawContentDependency, new NullFactory())
+      compilation.dependencyTemplates.set(RecordRawContentDependency, new RecordRawContentDependency.Template())
     })
 
     compiler.hooks.thisCompilation.tap('MpxWebpackPlugin', (compilation, { normalModuleFactory }) => {
@@ -566,6 +570,7 @@ class MpxWebpackPlugin {
           // 输出web专用配置
           webConfig: this.options.webConfig,
           vueContentCache: new Map(),
+          rawContent: new Map(),
           tabBarMap: {},
           defs: processDefs(this.options.defs),
           i18n: this.options.i18n,
@@ -1193,6 +1198,10 @@ class MpxWebpackPlugin {
           const outputMap = JSON.stringify({ ...pagesMap, ...componentsMap })
           const filename = this.options.generateBuildMap.filename || 'outputMap.json'
           compilation.assets[filename] = new RawSource(outputMap)
+        }
+
+        for (let [path, rawSource] of mpx.rawContent) {
+          compilation.assets[path] = rawSource
         }
 
         const {

--- a/packages/webpack-plugin/lib/json-compiler/index.js
+++ b/packages/webpack-plugin/lib/json-compiler/index.js
@@ -13,8 +13,10 @@ const createHelpers = require('../helpers')
 const createJSONHelper = require('./helper')
 const RecordGlobalComponentsDependency = require('../dependencies/RecordGlobalComponentsDependency')
 const RecordIndependentDependency = require('../dependencies/RecordIndependentDependency')
+const RecordRawContentDependency = require('../dependencies/RecordRawContentDependency')
 const { MPX_DISABLE_EXTRACTOR_CACHE, RESOLVE_IGNORED_ERR, JSON_JS_EXT } = require('../utils/const')
 const resolve = require('../utils/resolve')
+const { RawSource } = require('webpack').sources
 
 module.exports = function (content) {
   const nativeCallback = this.async()
@@ -98,14 +100,7 @@ module.exports = function (content) {
                 if (err) return callback(err)
                 if (!this._compilation) return callback()
                 const targetPath = path.relative(context, file)
-                this._compilation.assets[targetPath] = {
-                  size: function size () {
-                    return stats.size
-                  },
-                  source: function source () {
-                    return content
-                  }
-                }
+                this._module.addPresentationalDependency(new RecordRawContentDependency(targetPath, new RawSource(content)))
                 callback()
               })
             }


### PR DESCRIPTION
修复问题：声明了 `worker` 的代码，编译流程报错。

问题定位：在 `webpack/lib/SourceMapDevToolPlugin` 定义了 `processAssets` Hook，在这个 Hook 处理过程中进入 `getTaskForFile` 报错。应该是在 json-compiler 当中针对要输出的 worker 代码定义的是非标准的 source 类型：

```javascript
this._compilation.assets[targetPath] = {
    size: function size () {
       return stats.size
     },
     source: function source () {
        return content
      }
}
```

具体改动：

1. 在 json-compiler 处理当中针对 worker 代码，通过 RawSource 生成标准 assets content；
2. 支持 persist cache；