### PR TITLE
fix:修复tabbar输出H5无法切换的问题

### DIFF
--- a/packages/webpack-plugin/lib/runtime/optionProcessor.js
+++ b/packages/webpack-plugin/lib/runtime/optionProcessor.js
@@ -66,7 +66,7 @@ export default function processOption (
 
         // 处理人为操作
         if (!action) {
-          if (stack.length > 1 && (stack[stack.length - 2].path === to.path || (tabBarMap[stack[stack.length - 2].path.slice(1)] && tabBarMap[to.path.slice(1)]))) {
+          if (stack.length > 1 && stack[stack.length - 2].path === to.path) {
             action = {
               type: 'back',
               delta: 1
@@ -147,6 +147,7 @@ export default function processOption (
               global.__mpxRouter.needRemove = stack.filter((item) => {
                 if (tabBarMap[item.path.slice(1)]) {
                   tabItem = item
+                  tabItem.path = to.path
                   return false
                 }
                 return true

--- a/packages/webpack-plugin/lib/runtime/optionProcessor.js
+++ b/packages/webpack-plugin/lib/runtime/optionProcessor.js
@@ -66,7 +66,7 @@ export default function processOption (
 
         // 处理人为操作
         if (!action) {
-          if (stack.length > 1 && stack[stack.length - 2].path === to.path) {
+          if (stack.length > 1 && (stack[stack.length - 2].path === to.path || (tabBarMap[stack[stack.length - 2].path.slice(1)] && tabBarMap[to.path.slice(1)]))) {
             action = {
               type: 'back',
               delta: 1


### PR DESCRIPTION
修复部分场景下：从二级页面浏览器导航返回action为undefined时，未判断前后两个页面是否为tabbar item