### PR TITLE
fix(style-compiler): Adjusting the Postcss plugin order

### DIFF
--- a/packages/webpack-plugin/lib/style-compiler/index.js
+++ b/packages/webpack-plugin/lib/style-compiler/index.js
@@ -30,7 +30,7 @@ module.exports = function (css, map) {
 
   const inlineConfig = Object.assign({}, mpx.postcssInlineConfig, { defs })
   loadPostcssConfig(this, inlineConfig).then(config => {
-    const plugins = config.plugins.concat(trim)
+    const plugins = [trim] // init with trim plugin
     const options = Object.assign(
       {
         to: this.resourcePath,
@@ -78,6 +78,8 @@ module.exports = function (css, map) {
         prev: map
       }
     }
+
+    plugins.push(...config.plugins) // push user config plugins
 
     return postcss(plugins)
       .process(css, options)


### PR DESCRIPTION
调整用户 postcss 插件的执行顺序。

修复问题：

当用户使用 [postcss-css-variables](https://github.com/MadLittleMods/postcss-css-variables) 插件且将 [preserve](https://github.com/MadLittleMods/postcss-css-variables#preserve-default-false) 设置为 true 时，会使内置插件中的 rpx 等带有注释处理功能的插件无法按预期方式执行。

![image](https://github.com/didi/mpx/assets/38176179/28ac09f6-ed46-47ed-b8fa-67f607c02cca)

通过将内置插件的执行顺序提前用以解决此问题。