### PR TITLE
fix(web): fix refs regexp

### DIFF
--- a/packages/core/src/platform/builtInMixins/refsMixin.web.js
+++ b/packages/core/src/platform/builtInMixins/refsMixin.web.js
@@ -8,7 +8,7 @@ function getEl (ref) {
 
 function processRefs (refs) {
   Object.keys(refs).forEach((key) => {
-    const matched = /^__mpx_ref_([^_]+)__$/.exec(key)
+    const matched = /^__mpx_ref_(.+)__$/.exec(key)
     const rKey = matched && matched[1]
     if (rKey) {
       const ref = refs[key]


### PR DESCRIPTION
When using underscores as the value of refs prop, it will be lost during web runtime