### PR TITLE
Feat 支持PropType类型

### DIFF
--- a/packages/core/@types/index.d.ts
+++ b/packages/core/@types/index.d.ts
@@ -31,18 +31,22 @@ type ArrayType<T extends any[]> = T extends Array<infer R> ? R : never;
 // Mpx types
 type Data = object | (() => object)
 
-type PropType = StringConstructor | NumberConstructor | BooleanConstructor | ObjectConstructor | ArrayConstructor | null
+type PropConstructor<T = any> = {
+  new (...args: any[]): T & {};
+} | {
+  (): T;
+}
 
-interface PropOpt {
-  type: PropType
-  optionalTypes?: Array<PropType>
-  value?: any
+export type PropType<T> = PropConstructor<T>
 
-  observer? (value: any, old: any, changedPath: string): void
+type FullPropType<T> = {
+  type: PropType<T>;
+  value?: T;
+  optionalTypes?: PropType<T>[];
 }
 
 interface Properties {
-  [key: string]: WechatMiniprogram.Component.AllProperty
+  [key: string]: WechatMiniprogram.Component.AllProperty | PropType<any> | FullPropType<any>
 }
 
 interface Methods {
@@ -78,8 +82,12 @@ type PropValueType<Def> = Def extends {
   }
   ? T
   : Def extends (...args: any[]) => infer T
-    ? T
-    : any;
+  ? T
+  : Def extends FullPropType<infer T>
+  ? T
+  : Def extends PropType<infer T>
+  ? T 
+  : any;
 
 type GetPropsType<T> = {
   readonly [K in keyof T]: PropValueType<T[K]>


### PR DESCRIPTION
实现以下效果

```js
createComponent({
  properties: {
    data: {
      type: Object as PropType<{ xxx: string }>,
      value: {
        xxx: 'xxx',
      },
    },
  },
  setup(props) {
    props.data.xxx // 开发工具自动类型提示
    return {}
  },
})
```