### PR TITLE
feat: 局部构建兜底页面增加当前页面路由显示

### DIFF
--- a/packages/webpack-plugin/lib/json-compiler/default-page.mpx
+++ b/packages/webpack-plugin/lib/json-compiler/default-page.mpx
@@ -1,3 +1,27 @@
 <template>
   <view>局部构建兜底页面</view>
+  <view>当前路由：{{currentRoute}}</view>
 </template>
+
+<script>
+import { onLoad } from '@mpxjs/core'
+import { createPage } from '@mpxjs/core'
+
+createPage({
+  data() {
+    return {
+      currentRoute: '',
+    }
+  },
+  onLoad() {
+    this.getPagePath()
+  },
+  methods: {
+    getPagePath() {
+      const pages = getCurrentPages() || []
+      const currPage = pages[pages.length - 1]
+      this.currentRoute = currPage && currPage.route || ''
+    },
+  }
+})
+</script>


### PR DESCRIPTION
局部构建兜底页面中，获取并显示当前路由。便于开发、测试跳转时查看