### PR TITLE
fix: 修复babel-plugin-inject-page-events babel插件在babel.config.json中配置有o…

### DIFF
--- a/packages/babel-plugin-inject-page-events/src/index.js
+++ b/packages/babel-plugin-inject-page-events/src/index.js
@@ -41,7 +41,9 @@ module.exports = ({ parse }) => {
               if (idx + 1 !== state.sideEffectHooks.size) pageEventsFun += ','
             })
             const code = `global.currentInject.pageEvents = {${pageEventsFun}};`
-            const newAst = parse(code)
+            const newAst = parse(code, {
+              filename: state.filename
+            })
             path.unshiftContainer('body', newAst.program.body)
           }
         }


### PR DESCRIPTION
修复babel-plugin-inject-page-events babel插件在babel.config.json中配置有override后的报错问题。

![image](https://github.com/didi/mpx/assets/18080281/f81c36c9-190b-4fe5-8c6a-7bf94ef06401)
插件中在处理某个mpx文件时，会二次调用babel.parse，此次调用若不传递filename;
![image](https://github.com/didi/mpx/assets/18080281/48f12ebf-7af7-409c-b204-1d769f6935cc)
在parse方法中，默认会读取babel.config.json，判断是否存在overrides，若存在，则走configIsApplicable方法，里边的context中的filename为undefined；
![image](https://github.com/didi/mpx/assets/18080281/e259b49b-7ab0-4b2b-9c92-02388adbae80)
最终会导致此处出现babel parse 找不到filename的报错。因此插件中的二次parse处理需要添加filename