### PR TITLE
fix: 修复 mpx setup 区块内，ts类型定义会被合并为一行的问题

### DIFF
--- a/packages/core/@types/index.d.ts
+++ b/packages/core/@types/index.d.ts
@@ -292,6 +292,10 @@ export type Plugin = PluginInstallFunction | {
   install: PluginInstallFunction;
 };
 
+export type PluginFunction<T extends Plugin> = T extends PluginInstallFunction ? T : T extends { install: infer U } ? U : never;
+
+export type PluginFunctionParams<T extends PluginInstallFunction> = T extends (app: any, ...args: infer P) => any ? P : [];
+
 export interface Mpx {
   getMixin: typeof getMixin
   mixin: typeof injectMixins
@@ -300,7 +304,7 @@ export interface Mpx {
   observable: typeof observable
   watch: typeof watch
 
-  use (plugin: Plugin, ...rest: any[]): Mpx
+  use <T extends Plugin = Plugin>(plugin: T, ...rest: PluginFunctionParams<PluginFunction<T>>): Mpx
 
   implement (name: string, options?: ImplementOptions): void
 

--- a/packages/webpack-plugin/lib/script-setup-compiler/index.js
+++ b/packages/webpack-plugin/lib/script-setup-compiler/index.js
@@ -533,7 +533,7 @@ function compileScriptSetup (
         (node.type === 'VariableDeclaration' && node.declare)
       ) {
         recordType(node, declaredTypes)
-        _s.move(node.start, node.end, 0)
+        _s.move(node.start, node.end + 1, 0)
       }
     }
 


### PR DESCRIPTION
包含 2 更改：
[修复 mpx setup 区块内，ts类型定义会被合并为一行的问题](https://github.com/didi/mpx/pull/1352/commits/bf7cb5cfd729448d3872552ed8eb765c5cabcae7)
[perf: mpx.use 支持插件参数推导](https://github.com/didi/mpx/pull/1352/commits/140d794d2e7faa56b39f138e36e5c8dccd8b8835)
