### PR TITLE
fix: 完善PropType类型定义

### DIFF
--- a/packages/core/@types/index.d.ts
+++ b/packages/core/@types/index.d.ts
@@ -31,18 +31,25 @@ type ArrayType<T extends any[]> = T extends Array<infer R> ? R : never;
 // Mpx types
 type Data = object | (() => object)
 
-export type PropType<T> = T & (
-  T extends string 
+export type PropType<T> = Exclude<
+  T,
+  | StringConstructor
+  | NumberConstructor
+  | BooleanConstructor
+  | ArrayConstructor
+  | ObjectConstructor
+> &
+  (T extends string
     ? StringConstructor
-    : T extends number 
+    : T extends number
       ? NumberConstructor
       : T extends boolean
         ? BooleanConstructor
         : T extends any[]
           ? ArrayConstructor
-          : T extends object 
+          : T extends object
             ? ObjectConstructor
-            : never )
+            : never)
 
 type FullPropType<T> = {
   type: PropType<T>;


### PR DESCRIPTION
解决上次PropType的修改导致自动推断 type: Object 类型为 ObjectConstructor 的问题

上次提交的代码本地调试时是可以的，这次更新之后想体验一下发现又不行了，很奇怪，可能是我对ts还不太熟练，囧。