### PR TITLE
build(style): 增加前置postcss插件能力支持

### DIFF
--- a/docs-vuepress/api/compile.md
+++ b/docs-vuepress/api/compile.md
@@ -707,7 +707,7 @@ module.exports = defineConfig({
 })
 ```
 
-**注意：**默认添加的 postcss 插件均会在`mpx的内置插件`（例如如rpx插件等）之后处理。如需使配置的插件优先于内置插件，可以在插件 options 中设置 `mpxPrePlugin` 选项为 `true`。
+**注意：**默认添加的 postcss 插件均会在`mpx的内置插件`（例如如rpx插件等）之后处理。如需使配置的插件优先于内置插件，可以在 `postcssInlineConfig` 中添加 `mpxPrePlugins` 配置：
 
 ```js
 // vue.config.js

--- a/docs-vuepress/api/compile.md
+++ b/docs-vuepress/api/compile.md
@@ -719,15 +719,15 @@ module.exports = defineConfig({
           plugins: [
             require('postcss-import'),
             require('postcss-preset-env'),
-            require('cssnano')({ mpxPrePlugin: true }),
-            require('autoprefixer')({ remove: true, mpxPrePlugin: true })
+          ],
+          mpxPrePlugins: [
+            require('cssnano'),
+            require('autoprefixer')
           ]
           // 以下写法同理
-          // plugins: {
-          //   'postcss-import': {},
-          //   'postcss-preset-env': {},
-          //   'cssnano': { mpxPrePlugin: true },
-          //   'autoprefixer': { remove: true, mpxPrePlugin: true }
+          // mpxPrePlugins: {
+          //   'cssnano': {},
+          //   'autoprefixer': {}
           // }
         }
       }
@@ -737,6 +737,10 @@ module.exports = defineConfig({
 ```
 
 在上面这个例子当中，postcss 插件处理的最终顺序为：`cssnano` -> `autoprefixer` -> `mpx内置插件` -> `postcss-import` -> `postcss-preset-env`
+
+::: warning
+注意：在 `mpxPrePlugins` 中配置的 postcss 插件如果不通过 mpx 进行处理，那么将不会生效。
+:::
 
 ### decodeHTMLText
 

--- a/docs-vuepress/api/compile.md
+++ b/docs-vuepress/api/compile.md
@@ -707,6 +707,37 @@ module.exports = defineConfig({
 })
 ```
 
+**注意：**默认添加的 postcss 插件均会在`mpx的内置插件`（例如如rpx插件等）之后处理。如需使配置的插件优先于内置插件，可以在插件 options 中设置 `mpxPrePlugin` 选项为 `true`。
+
+```js
+// vue.config.js
+module.exports = defineConfig({
+  pluginOptions: {
+    mpx: {
+      plugin: {
+        postcssInlineConfig: {
+          plugins: [
+            require('postcss-import'),
+            require('postcss-preset-env'),
+            require('cssnano')({ mpxPrePlugin: true }),
+            require('autoprefixer')({ remove: true, mpxPrePlugin: true })
+          ]
+          // 以下写法同理
+          // plugins: {
+          //   'postcss-import': {},
+          //   'postcss-preset-env': {},
+          //   'cssnano': { mpxPrePlugin: true },
+          //   'autoprefixer': { remove: true, mpxPrePlugin: true }
+          // }
+        }
+      }
+    }
+  }
+})
+```
+
+在上面这个例子当中，postcss 插件处理的最终顺序为：`cssnano` -> `autoprefixer` -> `mpx内置插件` -> `postcss-import` -> `postcss-preset-env`
+
 ### decodeHTMLText
 
 `boolean = false`

--- a/packages/webpack-plugin/lib/style-compiler/index.js
+++ b/packages/webpack-plugin/lib/style-compiler/index.js
@@ -27,6 +27,7 @@ module.exports = function (css, map) {
     return matchCondition(this.resourcePath, { include, exclude })
   }
 
+  const inlineConfig = Object.assign({}, mpx.postcssInlineConfig, { defs })
   loadPostcssConfig(this, inlineConfig).then(config => {
     const plugins = [] // init with trim plugin
     const options = Object.assign(

--- a/packages/webpack-plugin/lib/style-compiler/index.js
+++ b/packages/webpack-plugin/lib/style-compiler/index.js
@@ -27,7 +27,6 @@ module.exports = function (css, map) {
     return matchCondition(this.resourcePath, { include, exclude })
   }
 
-  const inlineConfig = Object.assign({}, mpx.postcssInlineConfig, { defs })
   loadPostcssConfig(this, inlineConfig).then(config => {
     const plugins = [] // init with trim plugin
     const options = Object.assign(
@@ -82,17 +81,9 @@ module.exports = function (css, map) {
       }
     }
 
-    const prePlugins = []
+    const finalPlugins = config.prePlugins.concat(plugins, config.plugins)
 
-    config.plugins.forEach(e => {
-      if (e.options && e.options.mpxPrePlugin) {
-        prePlugins.push(e)
-      } else {
-        plugins.push(e)
-      }
-    })
-
-    return postcss(prePlugins.concat(plugins))
+    return postcss(finalPlugins)
       .process(css, options)
       .then(result => {
         // ali环境添加全局样式抹平root差异

--- a/packages/webpack-plugin/lib/style-compiler/index.js
+++ b/packages/webpack-plugin/lib/style-compiler/index.js
@@ -82,9 +82,17 @@ module.exports = function (css, map) {
       }
     }
 
-    plugins.push(...config.plugins) // push user config plugins
+    const prePlugins = []
 
-    return postcss(plugins)
+    config.plugins.forEach(e => {
+      if (e.options && e.options.mpxPrePlugin) {
+        prePlugins.push(e)
+      } else {
+        plugins.push(e)
+      }
+    })
+
+    return postcss(prePlugins.concat(plugins))
       .process(css, options)
       .then(result => {
         // ali环境添加全局样式抹平root差异

--- a/packages/webpack-plugin/lib/style-compiler/load-postcss-config.js
+++ b/packages/webpack-plugin/lib/style-compiler/load-postcss-config.js
@@ -1,4 +1,5 @@
 const load = require('postcss-load-config')
+const loadPlugins = require('postcss-load-config/src/plugins')
 
 let loaded
 
@@ -28,19 +29,25 @@ module.exports = function loadPostcssConfig (loaderContext, inlineConfig = {}) {
     })
   }
 
-  return loaded.then(config => {
+  return loaded.then((config = {}) => {
     let plugins = inlineConfig.plugins || []
     let options = inlineConfig.options || {}
+    let prePlugins = inlineConfig.prePlugins || []
 
     // merge postcss config file
-    if (config && config.plugins) {
+    if (config.plugins) {
       plugins = plugins.concat(config.plugins)
     }
-    if (config && config.options) {
+    if (config.options) {
       options = Object.assign({}, config.options, options)
+      if (config.options.mpxPrePlugins) {
+        // 使入参和postcss格式保持一致
+        prePlugins = prePlugins.concat(loadPlugins({ plugins: config.options.mpxPrePlugins }, config.file))
+      }
     }
 
     return {
+      prePlugins,
       plugins,
       options
     }


### PR DESCRIPTION
**注意**：默认添加的 postcss 插件均会在`mpx的内置插件`（例如如rpx插件等）之后处理。如需使配置的插件优先于内置插件，可以在 `postcssInlineConfig` 中添加 `mpxPrePlugins` 配置：
```js
// vue.config.js
module.exports = defineConfig({
  pluginOptions: {
    mpx: {
      plugin: {
        postcssInlineConfig: {
          plugins: [
            require('postcss-import'),
            require('postcss-preset-env'),
          ],
          mpxPrePlugins: [
            require('cssnano'),
            require('autoprefixer')
          ]
          // 以下写法同理
          // mpxPrePlugins: {
          //   'cssnano': {},
          //   'autoprefixer': {}
          // }
        }
      }
    }
  }
})
```
在上面这个例子当中，postcss 插件处理的最终顺序为：`cssnano` -> `autoprefixer` -> `mpx内置插件` -> `postcss-import` -> `postcss-preset-env`

**注意：在 `mpxPrePlugins` 中配置的 postcss 插件如果不通过 mpx 进行处理，那么将不会生效。**
