### PR TITLE
fix: 重写compiler.outputFileSystem.writeFile方法时适配其可选参数

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -365,13 +365,18 @@ class MpxWebpackPlugin {
     if (this.options.writeMode === 'changed') {
       const writedFileContentMap = new Map()
       const originalWriteFile = compiler.outputFileSystem.writeFile
-      compiler.outputFileSystem.writeFile = (filePath, content, callback) => {
+      // fs.writeFile(file, data[, options], callback)
+      compiler.outputFileSystem.writeFile = (filePath, content, ...args) => {
         const lastContent = writedFileContentMap.get(filePath)
         if (Buffer.isBuffer(lastContent) ? lastContent.equals(content) : lastContent === content) {
-          return callback()
+          const callback = args[args.length - 1]
+          if (typeof callback === 'function') {
+            callback()
+          }
+          return
         }
         writedFileContentMap.set(filePath, content)
-        originalWriteFile(filePath, content, callback)
+        originalWriteFile(filePath, content, ...args)
       }
     }
 


### PR DESCRIPTION
`node@20`, `webpack@5.89.0`环境下编译输出 `ali` 小程序，输出某个文件时，第三个参数实际为 `'utf8'`，第四个参数为预期的 `callback` 回调。
原因：compiler.outputFileSystem.writeFile 原始方法有不同的重载签名，参考：[fs.writeFile(file, data[, options], callback)](http://url.nodejs.cn/api/fs.html#fswritefilefile-data-options-callback) 。
