### PR TITLE
fix: pnpm下跨平台转换全局对象时路径匹配逻辑失效

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -1288,7 +1288,11 @@ class MpxWebpackPlugin {
               target = expr.object
             }
 
-            if (!matchCondition(resourcePath, this.options.transMpxRules) || resourcePath.indexOf('@mpxjs') !== -1 || !target || mode === srcMode) return
+            // 兼容 pnpm node_modules 路径
+            const lastIndex = resourcePath.lastIndexOf('node_modules')
+            const relativeResourcePath = lastIndex === -1 ? resourcePath : resourcePath.slice(lastIndex)
+
+            if (!matchCondition(relativeResourcePath, this.options.transMpxRules) || relativeResourcePath.indexOf('@mpxjs') !== -1 || !target || mode === srcMode) return
 
             const type = target.name
             const name = type === 'wx' ? 'mpx' : 'createFactory'

--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -1288,11 +1288,7 @@ class MpxWebpackPlugin {
               target = expr.object
             }
 
-            // 兼容 pnpm node_modules 路径
-            const lastIndex = resourcePath.lastIndexOf('node_modules')
-            const relativeResourcePath = lastIndex === -1 ? resourcePath : resourcePath.slice(lastIndex)
-
-            if (!matchCondition(relativeResourcePath, this.options.transMpxRules) || relativeResourcePath.indexOf('@mpxjs') !== -1 || !target || mode === srcMode) return
+            if (!matchCondition(resourcePath, this.options.transMpxRules) || resourcePath.indexOf('node_modules/@mpxjs') !== -1 || !target || mode === srcMode) return
 
             const type = target.name
             const name = type === 'wx' ? 'mpx' : 'createFactory'


### PR DESCRIPTION
~~- 由于 pnpm nested node_modules 非扁平结构，尤其是在 peers 造成的排列组合路径时，之前的匹配逻辑会错误命中。解决方案：从之前的绝对路径改为相对路径匹配，`pnpm` 路径下截取最后出现的 `node_modules` 之后的路径，这与常规的 `npm` 路径一致。~~

仅修改特定 `@mpxjs` 匹配规则 -> `node_modules/@mpxjs`，`options.transMpxRules` 通过在项目中配置对应的路径规则来解决 `pnpm` 下的问题。