### PR TITLE
Fix unocss feature cwy

### DIFF
--- a/packages/unocss-base/lib/index.js
+++ b/packages/unocss-base/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function presetMpx (options = {}) {
     name: '@mpxjs/unocss-base',
     theme: {
       ...uno.theme,
-      preflightRoot: ['page,view,text,::before,::after']
+      preflightRoot: ['page,view,text,::before,::after,::backdrop']
     },
     postprocess: (util) => {
       util.entries.forEach((i) => {

--- a/packages/unocss-base/lib/index.js
+++ b/packages/unocss-base/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function presetMpx (options = {}) {
     name: '@mpxjs/unocss-base',
     theme: {
       ...uno.theme,
-      preflightRoot: 'page'
+      preflightRoot: ['page,view,text,::before,::after']
     },
     postprocess: (util) => {
       util.entries.forEach((i) => {

--- a/packages/unocss-base/lib/index.js
+++ b/packages/unocss-base/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function presetMpx (options = {}) {
     name: '@mpxjs/unocss-base',
     theme: {
       ...uno.theme,
-      preflightRoot: ['page,view,text,::before,::after,::backdrop']
+      preflightRoot: ['page,view,text,div,span,::before,::after,::backdrop']
     },
     postprocess: (util) => {
       util.entries.forEach((i) => {

--- a/packages/unocss-plugin/lib/index.js
+++ b/packages/unocss-plugin/lib/index.js
@@ -86,16 +86,18 @@ function normalizeOptions (options) {
     config,
     configFiles,
     transformCSS,
-    transformGroups,
+    transformGroups, // false | true | { separators: [':','-'] }
     webOptions = {}
   } = options
+  // 是否兼容为true的写法
+  if (transformGroups) transformGroups = transformGroups instanceof Object ? transformGroups : {}
   // web配置
   // todo config读取逻辑通过UnoCSSWebpackPlugin内置逻辑进行，待改进
   webOptions = {
     include: scan.include || [],
     exclude: scan.exclude || [],
     transformers: [
-      ...transformGroups ? [transformerVariantGroup()] : [],
+      ...transformGroups ? [transformerVariantGroup(transformGroups)] : [],
       ...transformCSS ? [transformerDirectives()] : []
     ],
     ...webOptions
@@ -321,7 +323,7 @@ class MpxUnocssPlugin {
           // pre process
           source = transformAlias(source)
           if (this.options.transformGroups) {
-            source = transformGroups(source)
+            source = transformGroups(source, this.options.transformGroups)
           }
           const content = source.source()
           // escape & fill classesMap

--- a/packages/unocss-plugin/lib/transform.js
+++ b/packages/unocss-plugin/lib/transform.js
@@ -39,16 +39,14 @@ function buildAliasTransformer (alias) {
   }
 }
 const regexCache = {}
-function makeRegexClassGroup(separators = ['-', ':']) {
+function makeRegexClassGroup (separators = ['-', ':']) {
   const key = separators.join('|')
   if (!regexCache[key]) regexCache[key] = new RegExp(`((?:[!@<~\\w+:_/-]|\\[&?>?:?\\S*\\])+?)(${key})\\(((?:[~!<>\\w\\s:/\\\\,%#.$?-]|\\[.*?\\])+?)\\)(?!\\s*?=>)`, 'gm')
   regexCache[key].lastIndex = 0
   return regexCache[key]
 }
 
-
-
-function transformGroups (source, options={}) {
+function transformGroups (source, options = {}) {
   source = getReplaceSource(source)
   const content = source.original().source()
   let match


### PR DESCRIPTION
1.transformGroups支持选择器写法&配置分隔符
2.preflightRoot 对齐unocss，变更 'page'  ->  'page,view,text,::before,::after,::backdrop',修复父级变量影响子级的问题。我们只给 view,text加了，应该能覆盖大部分场景吧？
3. web 对齐需要 不同的preflightRoot，所以preflightRoot里还应有'div,span'， 看看我们是分环境配置，还是直接写在一起呢


