### PR TITLE
修复@mpxjs/store的类型问题

### DIFF
--- a/packages/store/@types/index.d.ts
+++ b/packages/store/@types/index.d.ts
@@ -65,7 +65,7 @@ type DepsSymbol = typeof DEPS_SYMBOL
 type StateSymbol = typeof STATE_SYMBOL
 type GettersSymbol = typeof GETTERS_SYMBOL
 
-interface Store<S = {}, G = {}, M = {}, A = {}, D extends Deps = {}> {
+export interface Store<S = {}, G = {}, M = {}, A = {}, D extends Deps = {}> {
 
   [DEPS_SYMBOL]: D
   [STATE_SYMBOL]: S


### PR DESCRIPTION
修复当在ts里使用 `export default createStore()`时的报错 "default export of the module has or is using private name 'Store'."