### PR TITLE
fix: 小程序部分机型::backdrop异常

### DIFF
--- a/packages/unocss-base/lib/index.js
+++ b/packages/unocss-base/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function presetMpx (options = {}) {
     name: '@mpxjs/unocss-base',
     theme: {
       ...uno.theme,
-      preflightRoot: ['page,view,text,div,span,::before,::after,::backdrop']
+      preflightRoot: ['page,view,text,div,span,::before,::after']
     },
     postprocess: (util) => {
       util.entries.forEach((i) => {


### PR DESCRIPTION
::backdrop在部分真机（iphone）下会导致渲染异常，与模拟器表现不符合。具体表现为含::backdrop的分组选择器样式失效。

``` css
/* 模拟器正常，真机失效 */
view,.abc,::backdrop {
} 

/*  模拟器、真机均正常 */
view,.abc {
}
```