### PR TITLE
bugfix: 导航条在安卓上体验问题&相交api错误

### DIFF
--- a/packages/api-proxy/src/platform/api/create-intersection-observer/rnIntersectionObserver.js
+++ b/packages/api-proxy/src/platform/api/create-intersection-observer/rnIntersectionObserver.js
@@ -96,7 +96,7 @@ class RNIntersectionObserver {
 
     const windowRect = {
       top: navigationLayout.y + this.margins.top,
-      left: navigationLayout.x + this.margins.left,
+      left: this.margins.left,
       right: navigationLayout.width - this.margins.right,
       bottom: navigationLayout.y + navigationLayout.height - this.margins.bottom
     }

--- a/packages/core/src/platform/createApp.ios.js
+++ b/packages/core/src/platform/createApp.ios.js
@@ -191,7 +191,8 @@ export default function createApp (option, config = {}) {
       // 7.x替换headerBackTitleVisible
       // headerBackButtonDisplayMode: 'minimal',
       headerBackTitleVisible: false,
-      headerMode: 'float'
+      // 安卓上会出现回退的时，如果设置为flat的话 navigator出现右滑退出，screen部分是fade的方式，交互效果不佳
+      headerMode: 'screen'
     }
     if (headerBackImageProps) {
       navScreenOpts.headerBackImage = () => {

--- a/packages/core/src/platform/createApp.ios.js
+++ b/packages/core/src/platform/createApp.ios.js
@@ -191,7 +191,7 @@ export default function createApp (option, config = {}) {
       // 7.x替换headerBackTitleVisible
       // headerBackButtonDisplayMode: 'minimal',
       headerBackTitleVisible: false,
-      // 安卓上会出现回退的时，如果设置为flat的话 navigator出现右滑退出，screen部分是fade的方式，交互效果不佳
+      // 安卓上回退时，如果设置为float的话 navigator出现右滑退出，screen其实是fade的方式退出，交互不匹配，体验差，另外float模式会导致偶现状态栏透出native部分
       headerMode: 'screen',
       // 安卓上会出现初始化时闪现导航条的问题
       headerShown: false

--- a/packages/core/src/platform/createApp.ios.js
+++ b/packages/core/src/platform/createApp.ios.js
@@ -191,8 +191,6 @@ export default function createApp (option, config = {}) {
       // 7.x替换headerBackTitleVisible
       // headerBackButtonDisplayMode: 'minimal',
       headerBackTitleVisible: false,
-      // 安卓上回退时，如果设置为float的话 navigator出现右滑退出，screen其实是fade的方式退出，交互不匹配，体验差，另外float模式会导致偶现状态栏透出native部分
-      headerMode: 'screen',
       // 安卓上会出现初始化时闪现导航条的问题
       headerShown: false
     }

--- a/packages/core/src/platform/createApp.ios.js
+++ b/packages/core/src/platform/createApp.ios.js
@@ -192,7 +192,9 @@ export default function createApp (option, config = {}) {
       // headerBackButtonDisplayMode: 'minimal',
       headerBackTitleVisible: false,
       // 安卓上会出现回退的时，如果设置为flat的话 navigator出现右滑退出，screen部分是fade的方式，交互效果不佳
-      headerMode: 'screen'
+      headerMode: 'screen',
+      // 安卓上会出现初始化时闪现导航条的问题
+      headerShown: false
     }
     if (headerBackImageProps) {
       navScreenOpts.headerBackImage = () => {


### PR DESCRIPTION
1. 安卓导航条回退的时候，动画与screen动画割裂
2. 安卓导航条初始化时闪现路径问题
3. 相交api使用layout里面的x值，x值目前不对，暂时先修改为不参考x值