### PR TITLE
fix: 修复预请求isCache标识不准问题

### DIFF
--- a/packages/fetch/src/xfetch.js
+++ b/packages/fetch/src/xfetch.js
@@ -176,7 +176,7 @@ export default class XFetch {
       if (isNotExpired && checkCacheConfig(config, cacheRequestData) && cacheRequestData.responsePromise) {
         return cacheRequestData.responsePromise.then(response => {
           // 添加 isCache 标识该请求来源于缓存
-          return extend(response, { isCache: true })
+          return extend({ isCache: true }, response)
         })
       } else {
         delete this.cacheRequestData[cacheKey]


### PR DESCRIPTION
命中缓存需要copy一个新的response对象用于添加isCache标识，防止污染原本的response对象。