### PR TITLE
Docs vitepress 0218

### DIFF
--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitepress"
 import { withPwa } from "@vite-pwa/vitepress"
-import { algoliaTranslations } from "./theme/translations"
+import {
+    algoliaTranslations,
+    localSearchTranslations,
+} from "./theme/translations"
 
 const sidebar = {
     "/guide/": [
@@ -282,13 +285,16 @@ export default withPwa(
         },
         themeConfig: {
             // navbar: false,
-            algolia: {
-                // apiKey: '7849f511f78afc4383a81f0137a91c0f',
-                appId: "DZ8S6HN0MP",
-                apiKey: "a34809e24ae1eb13ca3afc255d0a0cef",
-                indexName: "mpxjs",
-                placeholder: "搜索文档",
-                translations: algoliaTranslations,
+            search: {
+                provider: "local",
+                options: {
+                    // // apiKey: '7849f511f78afc4383a81f0137a91c0f',
+                    // appId: "DZ8S6HN0MP",
+                    // apiKey: "a34809e24ae1eb13ca3afc255d0a0cef",
+                    // indexName: "mpxjs",
+                    // placeholder: "搜索文档",
+                    translations: localSearchTranslations,
+                },
             },
             logo: "/favicon.ico",
             socialLinks: [

--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitepress"
 import { withPwa } from "@vite-pwa/vitepress"
 import {
+    groupIconMdPlugin,
+    groupIconVitePlugin,
+} from "vitepress-plugin-group-icons"
+import {
     algoliaTranslations,
     localSearchTranslations,
 } from "./theme/translations"
@@ -257,6 +261,15 @@ export default withPwa(
             },
         },
         ignoreDeadLinks: true,
+        markdown: {
+            theme: {
+                light: "github-light",
+                dark: "github-dark",
+            },
+            config(md) {
+                md.use(groupIconMdPlugin)
+            },
+        },
         pwa: {
             base: "/",
             scope: "/",
@@ -346,6 +359,10 @@ export default withPwa(
                 prev: "上一页",
                 next: "下一页",
             },
+        },
+        vite: {
+            logLevel: "info",
+            plugins: [groupIconVitePlugin()],
         },
         // @ts-ignore
         chainWebpack: (config) => {

--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -273,6 +273,7 @@ export default withPwa(
         pwa: {
             base: "/",
             scope: "/",
+            registerType: "prompt",
             includeAssets: ["favicon.ico", "logo.png"],
             manifest: {
                 name: "Mpx",

--- a/docs-vitepress/.vitepress/theme/components/CustomLayout.vue
+++ b/docs-vitepress/.vitepress/theme/components/CustomLayout.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
+import { nextTick, provide } from 'vue'
+// @ts-ignore
+import RegisterSW from './RegisterSW.vue'
+
+const { isDark } = useData()
+
+function enableTransitions() {
+  return 'startViewTransition' in document
+    && window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+}
+
+provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
+  if (!enableTransitions()) {
+    isDark.value = !isDark.value
+    return
+  }
+
+  const clipPath = [
+    `circle(0px at ${x}px ${y}px)`,
+    `circle(${Math.hypot(
+        Math.max(x, innerWidth - x),
+        Math.max(y, innerHeight - y),
+    )}px at ${x}px ${y}px)`,
+  ]
+
+  // @ts-ignore
+  await document.startViewTransition?.(async () => {
+    isDark.value = !isDark.value
+    await nextTick()
+  }).ready
+
+  document.documentElement.animate(
+    { clipPath: isDark.value ? clipPath.reverse() : clipPath },
+    {
+      duration: 300,
+      easing: 'ease-in',
+      pseudoElement: `::view-transition-${isDark.value ? 'old' : 'new'}(root)`,
+    },
+  )
+})
+</script>
+
+<template>
+  <DefaultTheme.Layout>
+    <template #layout-bottom>
+      <RegisterSW />
+    </template>
+  </DefaultTheme.Layout>
+</template>

--- a/docs-vitepress/.vitepress/theme/components/Navbar.vue
+++ b/docs-vitepress/.vitepress/theme/components/Navbar.vue
@@ -36,15 +36,15 @@
 </template>
 
 <script>
-// import SearchBox from "@SearchBox";
-import AlgoliaSearchBox from "../components/AlgoliaSearchBox.vue";
-import { useRoute, useRouter, useData } from "vitepress";
-import { computed, ref, onMounted, watch } from "vue";
+import { computed, ref, onMounted, watch } from "vue"
+import { useRoute, useRouter, useData } from "vitepress"
+import { VPNavBarSearch } from "vitepress/theme"
+// import AlgoliaSearchBox from "../components/AlgoliaSearchBox.vue"
 
 export default {
   components: {
     // SearchBox,
-    AlgoliaSearchBox
+    AlgoliaSearchBox: VPNavBarSearch // 首页替换为 local 搜索
   },
   setup() {
     const route = useRoute()
@@ -66,11 +66,12 @@ export default {
       if (path !== '/') {
         return ''
       }
-      return isSidebarOpen.value ? 'transform: translateY(0);' : ''
+      return isSidebarOpen.value ? 'transform: translateY(0);z-index: 0;display: none' : ''
     })
 
     const isAlgoliaSearch = computed(() => {
-      return theme.value.algolia && theme.value.algolia.apiKey && theme.value.algolia.indexName;
+      // local 暂时写死 true
+      return true //theme.value.algolia && theme.value.algolia.apiKey && theme.value.algolia.indexName;
     })
     algolia.value = theme.value.algolia
 

--- a/docs-vitepress/.vitepress/theme/components/RegisterSW.vue
+++ b/docs-vitepress/.vitepress/theme/components/RegisterSW.vue
@@ -1,28 +1,23 @@
 <script setup lang="ts">
 import { onBeforeMount, ref } from 'vue'
 
-const offlineReady = ref(false)
 const needRefresh = ref(false)
 
 let updateServiceWorker: (() => Promise<void>) | undefined
 
-function onOfflineReady() {
-  offlineReady.value = true
-}
 function onNeedRefresh() {
   needRefresh.value = true
 }
 async function close() {
-  offlineReady.value = false
   needRefresh.value = false
 }
 
 onBeforeMount(async () => {
+  // @ts-ignore
   const { registerSW } = await import('virtual:pwa-register')
   console.log('[SW] onBeforeMount')
   updateServiceWorker = registerSW({
     immediate: true,
-    onOfflineReady,
     onNeedRefresh,
     onRegistered() {
       console.info('Service Worker registered')
@@ -35,14 +30,14 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-  <template v-if="offlineReady || needRefresh">
+  <template v-if="needRefresh">
     <div
       class="pwa-toast"
       role="alertdialog"
       aria-labelledby="pwa-message"
     >
       <div id="pwa-message" class="mb-3">
-        {{ offlineReady ? '应用已准备好离线工作' : '📣 有新内容可用，请点击重新加载按钮以更新。' }}
+        有新内容可用，请单击重新加载按钮进行更新。
       </div>
       <button
         v-if="needRefresh"

--- a/docs-vitepress/.vitepress/theme/index.js
+++ b/docs-vitepress/.vitepress/theme/index.js
@@ -2,7 +2,9 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import Layout from './layouts/HomepageLayout.vue'
 import RegisterSW from "./components/RegisterSW.vue"
+
 import './styles/index.css'
+import 'virtual:group-icons.css'
 
 export default {
     ...DefaultTheme,

--- a/docs-vitepress/.vitepress/theme/index.js
+++ b/docs-vitepress/.vitepress/theme/index.js
@@ -1,26 +1,14 @@
-import { h } from 'vue'
-import DefaultTheme from 'vitepress/theme'
-import Layout from './layouts/HomepageLayout.vue'
-import RegisterSW from "./components/RegisterSW.vue"
+import { h } from "vue"
+import DefaultTheme from "vitepress/theme"
+import HomepageLayout from "./layouts/HomepageLayout.vue"
 
-import './styles/index.css'
-import 'virtual:group-icons.css'
+import "virtual:group-icons.css"
+import "./styles/index.css"
+import "./styles/switchAppearance.css"
 
 export default {
     ...DefaultTheme,
     Layout() {
-        return h(Layout, null, {
-            'layout-bottom': () => h(RegisterSW)
-        })
-    }
+        return h(HomepageLayout)
+    },
 }
-// export default {
-//   extend: '@vuepress/theme-default',
-//   plugins: [
-//     ['@vuepress/search', {
-//       searchMaxSuggestions: 10
-//     }],
-//     ['@vuepress/back-to-top'],
-//     formatHeaderSlugPlugin
-//   ]
-// }

--- a/docs-vitepress/.vitepress/theme/layouts/HomepageLayout.vue
+++ b/docs-vitepress/.vitepress/theme/layouts/HomepageLayout.vue
@@ -14,14 +14,14 @@
 </template>
 
 <script>
-import { watch } from 'vue'
-import { useData } from 'vitepress'
+import { watch } from "vue"
+import { useData } from "vitepress"
 import Content from "../global-components/Content.vue"
 import Footer from "../global-components/Footer.vue"
 import Navbar from "../components/Navbar.vue"
 import MobileView from "../components/MobileView.vue"
 import RegisterSW from "../components/RegisterSW.vue"
-import CustomLayout from '../components/CustomLayout.vue'
+import CustomLayout from "../components/CustomLayout.vue"
 
 export default {
   components: {

--- a/docs-vitepress/.vitepress/theme/layouts/HomepageLayout.vue
+++ b/docs-vitepress/.vitepress/theme/layouts/HomepageLayout.vue
@@ -4,37 +4,33 @@
       <Navbar />
       <mobile-view v-if="smallMode"></mobile-view>
       <Content v-else />
-      <LayoutBottom/>
+      <RegisterSW />
       <Footer />
     </div>
     <div v-else>
-      <!-- <Navbar /> -->
-      <Layout></Layout>
+      <CustomLayout />
     </div>
   </div>
 </template>
 
 <script>
 import { watch } from 'vue'
-import Navbar from "../components/Navbar.vue";
-import MobileView from "../components/MobileView.vue";
-import Content from "../global-components/Content.vue";
-import Footer from "../global-components/Footer.vue";
-import LayoutBottom from '../components/RegisterSW.vue'
-import DefaultTheme from 'vitepress/theme'
 import { useData } from 'vitepress'
+import Content from "../global-components/Content.vue"
+import Footer from "../global-components/Footer.vue"
+import Navbar from "../components/Navbar.vue"
+import MobileView from "../components/MobileView.vue"
+import RegisterSW from "../components/RegisterSW.vue"
+import CustomLayout from '../components/CustomLayout.vue'
 
-const { Layout } = DefaultTheme
-// import ParentLayout from '@parent-theme/layouts/Layout.vue'
 export default {
   components: {
     Navbar,
     Content,
     Footer,
-    Layout,
-    // ParentLayout,
-    MobileView,
-    LayoutBottom
+    CustomLayout,
+    RegisterSW,
+    MobileView
   },
   data () {
     return {

--- a/docs-vitepress/.vitepress/theme/styles/index.css
+++ b/docs-vitepress/.vitepress/theme/styles/index.css
@@ -142,21 +142,9 @@
 }
 
 /* Local Search */
-/* .VPLocalSearchBox {
-    .search-bar:focus-within {
-        border-color: var(--vt-c-brand-highlight) !important;
-    }
-    .search-actions button:hover {
-        color: var(--vt-c-brand) !important;
-    }
-    .result.selected {
-        .titles,
-        .title-icon {
-            color: var(--vt-c-brand) !important;
-        }
-        border-color: var(--vt-c-brand-highlight) !important;
-    }
-} */
+.VPLocalSearchBox {
+    z-index: 120 !important;
+}
 
 .pager-link.title {
     color: var(--vt-c-brand) !important;

--- a/docs-vitepress/.vitepress/theme/styles/index.css
+++ b/docs-vitepress/.vitepress/theme/styles/index.css
@@ -11,9 +11,9 @@
     --vt-c-divider-light: rgba(60, 60, 60, 0.12);
     --vt-c-brand-highlight: var(--vt-c-brand-dark);
     --vt-c-brand: var(--vt-c-green);
-    --vt-c-brand-dark: var(--vt-c-green-dark);
     --vt-c-brand-light: var(--vt-c-green-light);
     --vt-c-brand-dark: var(--vt-c-green-dark);
+    --vp-c-brand-1: var(--vt-c-brand);
 }
 
 .dark {
@@ -95,6 +95,7 @@
     }
 }
 
+/* Algolia Search */
 .DocSearch-Button {
     background-color: transparent;
 }
@@ -140,7 +141,24 @@
     }
 }
 
-.pager-link .title {
+/* Local Search */
+/* .VPLocalSearchBox {
+    .search-bar:focus-within {
+        border-color: var(--vt-c-brand-highlight) !important;
+    }
+    .search-actions button:hover {
+        color: var(--vt-c-brand) !important;
+    }
+    .result.selected {
+        .titles,
+        .title-icon {
+            color: var(--vt-c-brand) !important;
+        }
+        border-color: var(--vt-c-brand-highlight) !important;
+    }
+} */
+
+.pager-link.title {
     color: var(--vt-c-brand) !important;
 }
 

--- a/docs-vitepress/.vitepress/theme/styles/switchAppearance.css
+++ b/docs-vitepress/.vitepress/theme/styles/switchAppearance.css
@@ -1,0 +1,16 @@
+/* dark/light radial transition */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root),
+.dark::view-transition-new(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root),
+.dark::view-transition-old(root) {
+  z-index: 9999;
+}

--- a/docs-vitepress/.vitepress/theme/translations.ts
+++ b/docs-vitepress/.vitepress/theme/translations.ts
@@ -35,3 +35,25 @@ export const algoliaTranslations = {
         },
     },
 }
+
+export const localSearchTranslations = {
+    button: {
+        buttonText: "搜索文档",
+        buttonAriaLabel: "搜索文档",
+    },
+    modal: {
+        displayDetails: "显示详细列表",
+        resetButtonTitle: "重置搜索",
+        backButtonTitle: "关闭搜索",
+        noResultsText: "没有结果",
+        footer: {
+            selectText: "选择",
+            selectKeyAriaLabel: "输入",
+            navigateText: "导航",
+            navigateUpKeyAriaLabel: "上箭头",
+            navigateDownKeyAriaLabel: "下箭头",
+            closeText: "关闭",
+            closeKeyAriaLabel: "esc",
+        },
+    },
+}

--- a/docs-vitepress/api/compile.md
+++ b/docs-vitepress/api/compile.md
@@ -52,11 +52,21 @@ interface Rules {
 
 Mpx 编译构建跨平台小程序和 web 的 webpack 主插件，安装示例如下：
 
-```bash 
+::: code-group
+
+```sh [npm]
 npm install -D @mpxjs/webpack-plugin
-pnpm install -D @mpxjs/webpack-plugin
+```
+
+```sh [pnpm]
+pnpm add -D @mpxjs/webpack-plugin
+```
+
+```sh [yarn]
 yarn add -D @mpxjs/webpack-plugin
 ```
+
+:::
 
 使用示例如下：
 ```javascript

--- a/docs-vitepress/guide/basic/start.md
+++ b/docs-vitepress/guide/basic/start.md
@@ -1,9 +1,22 @@
 # 快速开始
 
 ## 安装脚手架
-```shell
+
+::: code-group
+
+```sh [npm]
 npm i -g @mpxjs/cli
 ```
+
+```sh [pnpm]
+pnpm add -g @mpxjs/cli
+```
+
+```sh [yarn]
+yarn global add @mpxjs/cli
+```
+
+:::
 
 > @mpxjs/cli文档 https://github.com/mpx-ecology/mpx-cli
 

--- a/docs-vitepress/package.json
+++ b/docs-vitepress/package.json
@@ -9,6 +9,7 @@
     "vue": "^3.4.37"
   },
   "devDependencies": {
+    "vitepress-plugin-group-icons": "^1.3.6",
     "workbox-window": "^7.1.0"
   }
 }

--- a/docs-vitepress/public/service-worker.js
+++ b/docs-vitepress/public/service-worker.js
@@ -1,17 +1,30 @@
 // force an unregister
 // see https://discord.com/channels/325477692906536972/790509637598314527/1032614068164493402
-self.addEventListener('install', function (e) {
+// see https://vite-pwa-org-zh.netlify.app/guide/unregister-service-worker
+self.addEventListener('install', (e) => {
     console.log('[old service-worker] install', e)
     self.skipWaiting()
 })
-self.addEventListener('activate', function (e) {
+self.addEventListener('activate', (e) => {
     console.log('[old service-worker] activate', e)
     self.registration
         .unregister()
-        .then(function () {
-            return self.clients.matchAll()
+        .then(() => self.clients.matchAll())
+        .then((clients) => {
+            clients.forEach((client) => {
+                if (client && client.navigate && client.url) {
+                    client.navigate(client.url)
+                }
+            })
+            return Promise.resolve()
         })
-        .then(function (clients) {
-            clients.forEach((client) => client.navigate(client.url))
+        .then(() => {
+            self.caches.keys().then((cacheNames) => {
+                Promise.all(
+                    cacheNames.map((cacheName) => {
+                        return self.caches.delete(cacheName)
+                    })
+                )
+            })
         })
 })


### PR DESCRIPTION
## Feature

- 配置更新，支持 code groups icons，效果如下：
<img width="600" alt="Snipaste_2025-02-18_16-14-52" src="https://github.com/user-attachments/assets/83808a9d-6dca-4637-bd19-b080ea66fe5d" />


- 浅色/深色开关动画特效（https://github.com/nuxt/devtools/pull/224）

## Fix: 
- 搜索从 Algolia 改为 local，修复搜索失效 & vitepress 搜索渲染问题
- 更新旧版本站点 service-worker.js 销毁逻辑