### PR TITLE
fix: hummer相关依赖使用宿主环境的版本

### DIFF
--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -61,7 +61,10 @@
     "source-list-map": "^2.0.0"
   },
   "peerDependencies": {
-    "webpack": "^5.48.0"
+    "webpack": "^5.48.0",
+    "@hummer/tenon-dev-server-webpack-plugin": "0.0.2",
+    "@hummer/tenon-loader": "^1.2.0",
+    "@hummer/tenon-style-loader": "^0.2.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",


### PR DESCRIPTION
修复tenon_2.8版本上一些依赖包版本过高