### PR TITLE
修复rn hmr代码更新页面效果不刷新问题

### DIFF
--- a/packages/core/src/platform/patch/getDefaultOptions.ios.js
+++ b/packages/core/src/platform/patch/getDefaultOptions.ios.js
@@ -451,6 +451,15 @@ const provideRelation = (instance, relation) => {
     }
   }
 }
+
+const needHMRFresh = (currentInject) => {
+  if (!currentInject.HMRSysbmol) return false
+  const HMRSysbmolRef = useRef(currentInject.HMRSysbmol)
+  const HMRFresh = HMRSysbmolRef.current !== currentInject.HMRSysbmol
+  if (HMRFresh) HMRSysbmolRef.current = currentInject.HMRSysbmol
+  return HMRFresh
+}
+
 export function getDefaultOptions ({ type, rawOptions = {}, currentInject }) {
   rawOptions = mergeOptions(rawOptions, type, false)
   const components = Object.assign({}, rawOptions.components, currentInject.getComponents())
@@ -468,8 +477,9 @@ export function getDefaultOptions ({ type, rawOptions = {}, currentInject }) {
       relation = useContext(RelationsContext)
     }
     propsRef.current = props
+
     let isFirst = false
-    if (!instanceRef.current) {
+    if (!instanceRef.current || needHMRFresh(currentInject)) {
       isFirst = true
       instanceRef.current = createInstance({ propsRef, type, rawOptions, currentInject, validProps, components, pageId, intersectionCtx, relation, parentProvides })
     }

--- a/packages/webpack-plugin/lib/react/script-helper.js
+++ b/packages/webpack-plugin/lib/react/script-helper.js
@@ -126,6 +126,7 @@ global.currentInject.firstPage = ${JSON.stringify(firstPage)}\n`
   content += `global.currentSrcMode = ${JSON.stringify(scriptSrcMode)}\n`
   if (!isProduction) {
     content += `global.currentResource = ${JSON.stringify(loaderContext.resourcePath)}\n`
+    content += 'global.currentInject.HMRSysbmol = Symbol()\n'
   }
   return content
 }


### PR DESCRIPTION
组件通过 instanceRef 换成了 currentInject 中的render函数、css样式等组件渲染信息，RN HMR不会刷新 Ref 数据。导致代码中最新的 render 函数无法被使用。

为每个组件模块增加了标识，当模块被重新加载后创建新的标识对象。 getDefaultOptions 通过判断ref中的标识与当前模块最新标识是否一致作为当前模块是否被 HMR 机制重新加载的依据。