### PR TITLE
fix: async chunk push expression

### DIFF
--- a/packages/size-report/package.json
+++ b/packages/size-report/package.json
@@ -25,6 +25,8 @@
   "author": "xuegan",
   "license": "Apache-2.0",
   "dependencies": {
+    "acorn": "^8.11.3",
+    "acorn-walk": "^7.2.0",
     "ejs": "^3.1.6",
     "express": "^4.17.1",
     "loader-utils": "^2.0.0",


### PR DESCRIPTION
size-report analyze

before:
 ```unknown
 (window.webpackJsonp = window.webpackJsonp||[]).push([[<chunks>], <modules>, ...])
                                                 ^^^^
 ```
after:
 ```unknown
 var a = 'push';
 (window.webpackJsonp = window.webpackJsonp||[])[a]([[<chunks>], <modules>, ...])
                                                ^^^
 ```