### PR TITLE
fix: 修复RN热更新后mpxPagesMap为空问题

### DIFF
--- a/packages/core/src/platform/patch/getDefaultOptions.ios.js
+++ b/packages/core/src/platform/patch/getDefaultOptions.ios.js
@@ -656,8 +656,11 @@ export function getDefaultOptions ({ type, rawOptions = {}, currentInject }) {
       return () => {
         proxy.unmounted()
         proxy.target.__resetInstance()
-        if (type === 'page') {
-          delete global.__mpxPagesMap[props.route.key]
+        // 热更新下会销毁旧页面并创建新页面组件，且旧页面销毁时机晚于新页面创建，此时页面栈中存储的为新页面，不应该删除
+        // 所以需要判断路由表中存储的页面实例是否为当前页面实例
+        const routeKey = props.route.key
+        if (type === 'page' && global.__mpxPagesMap[routeKey] && global.__mpxPagesMap[routeKey][0] === instance) {
+          delete global.__mpxPagesMap[routeKey]
         }
       }
     }, [])


### PR DESCRIPTION
目前热更新后会销毁旧的页面组件并创建新页面组件，且旧页面组件销毁时机晚于新页面组件创建时机。
导致旧页面移除的mpxPagesMap其实是新页面的mpxPagesMap数据，最终导致mpxPagesMap为空。