### PR TITLE
fix: 修复getCurrentPageId 方法报错

### DIFF
--- a/packages/api-proxy/src/common/js/utils.js
+++ b/packages/api-proxy/src/common/js/utils.js
@@ -91,7 +91,7 @@ function failHandle (result, fail, complete) {
 
 function getCurrentPageId () {
   const currentInstance = getCurrentInstance()
-  const id = currentInstance?.getPageId() || getFocusedNavigation()?.pageId || null
+  const id = currentInstance?.proxy?.getPageId() || getFocusedNavigation()?.pageId || null
   return id
 }
 


### PR DESCRIPTION
* 修复api-proxy 内 getCurrentPageId 方法报错