### PR TITLE
fix: delayed rendering issue of the Swiper in HarmonyOS

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-swiper-item.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-swiper-item.tsx
@@ -3,7 +3,7 @@ import Animated, { useAnimatedStyle, interpolate, SharedValue } from 'react-nati
 import { ReactNode, forwardRef, useRef, useContext } from 'react'
 import useInnerProps from './getInnerListeners'
 import useNodesRef, { HandlerRef } from './useNodesRef' // 引入辅助函数
-import { useTransformStyle, splitStyle, splitProps, wrapChildren, useLayout, extendObject } from './utils'
+import { useTransformStyle, splitStyle, splitProps, wrapChildren, useLayout, extendObject, isHarmony } from './utils'
 import { SwiperContext } from './context'
 
 interface SwiperItemProps {
@@ -80,7 +80,7 @@ const _SwiperItem = forwardRef<HandlerRef<View, SwiperItemProps>, SwiperItemProp
     ],
     { layoutRef })
   const itemAnimatedStyle = useAnimatedStyle(() => {
-    if (!step.value) return {}
+    if (!step.value && !isHarmony) return {}
     const inputRange = [step.value, 0]
     const outputRange = [0.7, 1]
     // 实现元素的宽度跟随step从0到真实宽度，且不能触发重新渲染整个组件，通过AnimatedStyle的方式实现


### PR DESCRIPTION
## Fix
- 问题现象：鸿蒙端上，swiper 组件渲染（wx:if 控制）时 item 高度没有自动跟随 step.value 变化，得等到首次自动滚动或者 touch 之后高度正常变化。