### PR TITLE
fix: web uno失效

### DIFF
--- a/packages/unocss-plugin/lib/web-plugin/consts.js
+++ b/packages/unocss-plugin/lib/web-plugin/consts.js
@@ -24,7 +24,7 @@ function resolveLayer (id) {
   if (match) { return match[1] || LAYER_MARK_ALL }
 }
 
-const LAYER_PLACEHOLDER_RE = /(\\?")?#--unocss--\s*{\s*layer\s*:\s*(.+?);?\s*}/g
+const LAYER_PLACEHOLDER_RE = /(\\?")?#(?:\\)?--unocss--\s*{\s*layer\s*:\s*(.+?);?\s*}/g
 function getLayerPlaceholder (layer) {
   return `#--unocss--{layer:${layer}}`
 }


### PR DESCRIPTION
fix web uno失效。 源码被转义了，导致正则没匹配上