### PR TITLE
file-loader 添加 mpxAssetPaths 标识

### DIFF
--- a/packages/webpack-plugin/lib/file-loader.js
+++ b/packages/webpack-plugin/lib/file-loader.js
@@ -49,10 +49,10 @@ module.exports = function loader (content, prevOptions) {
     publicPath = JSON.stringify(publicPath)
   }
 
-  if (!this._module.mpxAssetPaths) {
-    this._module.mpxAssetPaths = new Set()
+  if (!this._module.buildInfo.mpxAssetPaths) {
+    this._module.buildInfo.mpxAssetPaths = new Set()
   }
-  this._module.mpxAssetPaths.add(publicPath)
+  this._module.buildInfo.mpxAssetPaths.add(publicPath)
 
   this.emitFile(outputPath, content)
 

--- a/packages/webpack-plugin/lib/file-loader.js
+++ b/packages/webpack-plugin/lib/file-loader.js
@@ -49,6 +49,11 @@ module.exports = function loader (content, prevOptions) {
     publicPath = JSON.stringify(publicPath)
   }
 
+  if (!this._module.mpxAssetPaths) {
+    this._module.mpxAssetPaths = new Set()
+  }
+  this._module.mpxAssetPaths.add(publicPath)
+
   this.emitFile(outputPath, content)
 
   // TODO revert to ES2015 Module export, when new CSS Pipeline is in place


### PR DESCRIPTION
新增 mpxAssetPaths 标识，供其他插件通过 compilation.modules 读取，进行文件路径收集