### PR TITLE
refactor: web picker-view&picker-view-column

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
@@ -15,6 +15,7 @@ BScroll.use(Wheel)
 
 export default {
   name: 'mpx-picker-view-column',
+  inject: ['indicatorMaskHeight'],
   props: {
     value: Array,
     scrollOptions: {
@@ -28,10 +29,9 @@ export default {
     return {
       wheels: [],
       selectedIndex: [0],
-      indicatorMaskHeight: 0
+      currentIndicatorMaskHeight: 0
     }
   },
-  computed: {},
   watch: {
     selectedIndex (newVal) {
       if (this.wheels[0]) {
@@ -42,10 +42,18 @@ export default {
         })
       }
     },
+    indicatorMaskHeight: {
+      handler(newHeight) {
+        if (newHeight && newHeight !== this.currentIndicatorMaskHeight) {
+          this.currentIndicatorMaskHeight = newHeight
+          this.refresh()
+        }
+      },
+      immediate: true
+    }
   },
   mounted () {
     this.wheels = []
-    this.indicatorMaskHeight = this.$parent.$refs?.indicatorMask?.offsetHeight || 0
     this.refresh()
   },
   updated () {
@@ -63,8 +71,8 @@ export default {
      
       this.refreshing = true
       for (let i = 0; i < this.$refs.wheelScroll.children.length; i++) {
-        if (this.indicatorMaskHeight) {
-          this.$refs.wheelScroll.children[i].style.height = this.indicatorMaskHeight + 'px'
+        if (this.currentIndicatorMaskHeight) {
+          this.$refs.wheelScroll.children[i].style.height = this.currentIndicatorMaskHeight + 'px'
         }
       }
       this.$nextTick(() => {

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
@@ -27,7 +27,9 @@ export default {
   data () {
     return {
       wheels: [],
-      selectedIndex: [0]
+      selectedIndex: [0],
+      cachedIndicatorMaskHeight: 0, // 缓存指示器高度
+      refreshTimer: null // 防抖定时器
     }
   },
   computed: {},
@@ -41,27 +43,71 @@ export default {
         })
       }
     },
+    // 监听父组件的indicatorStyle变化
+    '$parent.indicatorStyle': {
+      handler() {
+        // 使用防抖版本，避免频繁调用
+        this.debouncedRefresh()
+      },
+      immediate: false
+    }
   },
   mounted () {
     this.wheels = []
     this.refresh()
   },
-  updated () {
-    this.refresh()
+  // 移除updated钩子，改为使用activated处理页面切换
+  activated () {
+    // 页面被激活时，检查是否需要重新计算尺寸
+    if (this.cachedIndicatorMaskHeight === 0) {
+      this.$nextTick(() => {
+        this.refresh()
+      })
+    }
   },
   beforeDestroy () {
+    // 清理定时器
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer)
+    }
     this.wheels.forEach((wheel) => {
       wheel.destroy()
     })
     this.wheels = []
   },
   methods: {
+    // 防抖版本的refresh
+    debouncedRefresh() {
+      if (this.refreshTimer) {
+        clearTimeout(this.refreshTimer)
+      }
+      this.refreshTimer = setTimeout(() => {
+        this.refresh()
+      }, 16) // 大约一帧的时间
+    },
+    
     refresh () {
       if (this.refreshing) return
      
       this.refreshing = true
+      const indicatorMask = this.$parent.$refs.indicatorMask
+      let indicatorMaskHeight = indicatorMask.offsetHeight
+      
+      if (!indicatorMaskHeight) {
+        const computedStyle = getComputedStyle(indicatorMask)
+        indicatorMaskHeight = parseInt(computedStyle.height) || 0
+      }
+      
+      // 缓存有效的高度值
+      if (indicatorMaskHeight > 0) {
+        this.cachedIndicatorMaskHeight = indicatorMaskHeight
+      } else if (this.cachedIndicatorMaskHeight > 0) {
+        // 如果获取不到当前高度，使用缓存值
+        indicatorMaskHeight = this.cachedIndicatorMaskHeight
+      }
+
       for (let i = 0; i < this.$refs.wheelScroll.children.length; i++) {
-        this.$refs.wheelScroll.children[i].style.height = `${this.$parent.$refs.indicatorMask.offsetHeight}px`
+        this.$refs.wheelScroll.children[i].style.height = `${indicatorMaskHeight}px`
       }
       this.$nextTick(() => {
         const wheelWrapper = this.$refs.wheelWrapper

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
@@ -16,8 +16,7 @@
   export default {
     name: 'mpx-picker-view-column',
     inject: ['indicatorMaskHeight'],
-    props: {
-      value: Array,
+      props: {
       scrollOptions: {
         type: Object,
         default: () => {
@@ -28,20 +27,19 @@
     data() {
       return {
         wheel: null,
-        selectedIndex: [0],
+        selectedIndex: 0,
         currentIndicatorMaskHeight: 0,
         childrenCount: 0
       }
     },
     watch: {
       selectedIndex(newVal, oldVal) {
-        console.log('selectedIndex changed from', oldVal, 'to', newVal)
+        // console.log('selectedIndex changed from', oldVal, 'to', newVal)
+        // console.log('currentIndex', this.wheel.getSelectedIndex())
         if (this.wheel) {
-          const currentActualIndex = this.wheel.getSelectedIndex()[0] || 0
-          console.log('wheelTo', newVal[0], 'from actual:', currentActualIndex)
           this.$nextTick(() => {
             this.wheel.refresh()
-            this.wheel.wheelTo(newVal[0])
+            this.wheel.wheelTo(newVal)
 
             // 通知 picker-view wheelTo 完成
             this.$nextTick(() => {
@@ -101,7 +99,7 @@
           }
           this.wheel = new BScroll(wheelWrapper, extend({
             wheel: {
-              selectedIndex: this.selectedIndex[0],
+              selectedIndex: this.selectedIndex,
               rotate: -5,
               wheelWrapperClass: 'wheel-scroll'
             },
@@ -114,7 +112,7 @@
             }
           }.bind(this))
           this.wheel.on('scrollEnd', function () {
-            console.log('scrollEnd', this.refreshing)
+            // console.log('scrollEnd', this.refreshing)
             if (this.refreshing) return
             if (this.pickerView) {
               this.pickerView.notifyChange()

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
@@ -27,18 +27,19 @@ export default {
   },
   data () {
     return {
-      wheels: [],
+      wheel: null,
       selectedIndex: [0],
-      currentIndicatorMaskHeight: 0
+      currentIndicatorMaskHeight: 0,
+      childrenCount: 0
     }
   },
   watch: {
     selectedIndex (newVal) {
-      if (this.wheels[0]) {
+      if (this.wheel) {
         this.$nextTick(() => {
           // make sure the dom rendering is complete
-          this.wheels[0].refresh()
-          this.wheels[0].wheelTo(newVal[0])
+          this.wheel.refresh()
+          this.wheel.wheelTo(newVal[0])
         })
       }
     },
@@ -53,17 +54,21 @@ export default {
     }
   },
   mounted () {
-    this.wheels = []
+    this.wheel = null
+    this.childrenCount = this.$refs.wheelScroll ? this.$refs.wheelScroll.children.length : 0
     this.refresh()
   },
   updated () {
-    this.refresh()
+    const currentChildrenCount = this.$refs.wheelScroll ? this.$refs.wheelScroll.children.length : 0
+    if (currentChildrenCount !== this.childrenCount) {
+      this.childrenCount = currentChildrenCount
+      this.refresh()
+    }
   },
   beforeDestroy () {
-    this.wheels.forEach((wheel) => {
-      wheel.destroy()
-    })
-    this.wheels = []
+    if (this.wheel) {
+      this.wheel.destroy()
+    }
   },
   methods: {
     refresh () {
@@ -77,12 +82,12 @@ export default {
       }
       this.$nextTick(() => {
         const wheelWrapper = this.$refs.wheelWrapper
-        if (this.wheels[0]) {
-          this.wheels[0].refresh()
+        if (this.wheel) {
+          this.wheel.refresh()
           this.refreshing = false
           return
         }
-        this.wheels[0] = new BScroll(wheelWrapper, extend({
+        this.wheel = new BScroll(wheelWrapper, extend({
           wheel: {
             selectedIndex: this.selectedIndex[0],
             rotate: -5,
@@ -91,12 +96,12 @@ export default {
           probeType: 3,
           bindToWrapper: true
         }, this.scrollOptions))
-        this.wheels[0].on('scrollStart', function () {
+        this.wheel.on('scrollStart', function () {
           if (this.pickerView) {
             this.pickerView.notifyPickstart()
           }
         }.bind(this))
-        this.wheels[0].on('scrollEnd', function () {
+        this.wheel.on('scrollEnd', function () {
           if (this.refreshing) return
           if (this.pickerView) {
             this.pickerView.notifyChange()

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
@@ -61,7 +61,6 @@
       }
     },
     mounted() {
-      this.wheel = null
       this.childrenCount = this.$refs.wheelScroll ? this.$refs.wheelScroll.children.length : 0
       this.setColumnHeight()
       this.refresh()
@@ -76,10 +75,11 @@
     beforeDestroy() {
       if (this.wheel) {
         this.wheel.destroy()
+        this.wheel = null
       }
     },
     methods: {
-      setColumnHeight(height) {
+      setColumnHeight() {
         for (let i = 0; i < this.$refs.wheelScroll.children.length; i++) {
           if (this.currentIndicatorMaskHeight) {
             this.$refs.wheelScroll.children[i].style.height = this.currentIndicatorMaskHeight + 'px'
@@ -88,16 +88,15 @@
       },
       refresh() {
         if (this.refreshing) return
-
         this.refreshing = true
         this.$nextTick(() => {
-          const wheelWrapper = this.$refs.wheelWrapper
           if (this.wheel) {
             this.wheel.refresh()
             this.refreshing = false
             return
           }
-          this.wheel = new BScroll(wheelWrapper, extend({
+
+          this.wheel = new BScroll(this.$refs.wheelWrapper, extend({
             wheel: {
               selectedIndex: this.selectedIndex,
               rotate: -5,
@@ -106,19 +105,22 @@
             probeType: 3,
             bindToWrapper: true
           }, this.scrollOptions))
-          this.wheel.on('scrollStart', function () {
+
+          this.wheel.on('scrollStart', () => {
             if (this.pickerView) {
               this.pickerView.notifyPickstart()
             }
-          }.bind(this))
-          this.wheel.on('scrollEnd', function () {
+          })
+
+          this.wheel.on('scrollEnd', () => {
             // console.log('scrollEnd', this.refreshing)
             if (this.refreshing) return
             if (this.pickerView) {
               this.pickerView.notifyChange()
               this.pickerView.notifyPickend()
             }
-          }.bind(this))
+          })
+
           this.refreshing = false
         })
       }

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
@@ -7,131 +7,125 @@
 </template>
 
 <script type="text/ecmascript-6">
-import BScroll from '@better-scroll/core'
-import Wheel from '@better-scroll/wheel'
-import { extend } from '../../utils'
+  import BScroll from '@better-scroll/core'
+  import Wheel from '@better-scroll/wheel'
+  import { extend } from '../../utils'
 
-BScroll.use(Wheel)
+  BScroll.use(Wheel)
 
-export default {
-  name: 'mpx-picker-view-column',
-  inject: ['indicatorMaskHeight'],
-  props: {
-    value: Array,
-    scrollOptions: {
-      type: Object,
-      default: () => {
-        return {}
-      }
-    }
-  },
-  data () {
-    return {
-      wheel: null,
-      selectedIndex: [0],
-      currentIndicatorMaskHeight: 0,
-      childrenCount: 0,
-      lastSelectedIndex: [0]
-    }
-  },
-  watch: {
-    selectedIndex (newVal, oldVal) {
-      if (this.wheel) {
-        // 获取滚轮当前实际位置
-        const currentActualIndex = this.wheel.getSelectedIndex()
-        console.log('column selectedIndex changed', newVal, 'wheel actual:', currentActualIndex)
-        
-        // 只有当新值与滚轮实际位置不同时才执行 wheelTo
-        if (newVal[0] !== currentActualIndex) {
-          console.log('wheelTo', newVal[0], 'from actual:', currentActualIndex)
-          this.lastSelectedIndex = [...newVal]
-          this.$nextTick(() => {
-            // make sure the dom rendering is complete
-            this.wheel.refresh()
-            this.wheel.wheelTo(newVal[0])
-          })
-        } else {
-          // 即使值相同，也要更新 lastSelectedIndex，保持状态同步
-          this.lastSelectedIndex = [...newVal]
+  export default {
+    name: 'mpx-picker-view-column',
+    inject: ['indicatorMaskHeight'],
+    props: {
+      value: Array,
+      scrollOptions: {
+        type: Object,
+        default: () => {
+          return {}
         }
       }
     },
-    indicatorMaskHeight: {
-      handler(newHeight) {
-        if (newHeight && newHeight !== this.currentIndicatorMaskHeight) {
-          this.currentIndicatorMaskHeight = newHeight
-          this.refresh()
+    data() {
+      return {
+        wheel: null,
+        selectedIndex: [0],
+        currentIndicatorMaskHeight: 0,
+        childrenCount: 0
+      }
+    },
+    watch: {
+      selectedIndex(newVal, oldVal) {
+        console.log('selectedIndex changed from', oldVal, 'to', newVal)
+        if (this.wheel) {
+          const currentActualIndex = this.wheel.getSelectedIndex()[0] || 0
+          console.log('wheelTo', newVal[0], 'from actual:', currentActualIndex)
+          this.$nextTick(() => {
+            this.wheel.refresh()
+            this.wheel.wheelTo(newVal[0])
+
+            // 通知 picker-view wheelTo 完成
+            this.$nextTick(() => {
+              if (this.pickerView && this.pickerView.isExternalUpdate) {
+                this.pickerView.onWheelToComplete()
+              }
+            })
+          })
         }
       },
-      immediate: true
-    }
-  },
-  mounted () {
-    this.wheel = null
-    this.childrenCount = this.$refs.wheelScroll ? this.$refs.wheelScroll.children.length : 0
-    this.refresh()
-  },
-  updated () {
-    const currentChildrenCount = this.$refs.wheelScroll ? this.$refs.wheelScroll.children.length : 0
-    if (currentChildrenCount !== this.childrenCount) {
-      this.childrenCount = currentChildrenCount
-      this.refresh()
-    }
-  },
-  beforeDestroy () {
-    if (this.wheel) {
-      this.wheel.destroy()
-    }
-  },
-  methods: {
-    refresh () {
-      if (this.refreshing) return
-     
-      this.refreshing = true
-      for (let i = 0; i < this.$refs.wheelScroll.children.length; i++) {
-        if (this.currentIndicatorMaskHeight) {
-          this.$refs.wheelScroll.children[i].style.height = this.currentIndicatorMaskHeight + 'px'
-        }
+      indicatorMaskHeight: {
+        handler(newHeight) {
+          if (newHeight && newHeight !== this.currentIndicatorMaskHeight) {
+            this.currentIndicatorMaskHeight = newHeight
+            this.refresh()
+          }
+        },
+        immediate: true
       }
-      this.$nextTick(() => {
-        const wheelWrapper = this.$refs.wheelWrapper
-        if (this.wheel) {
-          this.wheel.refresh()
-          this.refreshing = false
-          return
+    },
+    mounted() {
+      this.wheel = null
+      this.childrenCount = this.$refs.wheelScroll ? this.$refs.wheelScroll.children.length : 0
+      this.setColumnHeight()
+      this.refresh()
+    },
+    updated() {
+      const currentChildrenCount = this.$refs.wheelScroll ? this.$refs.wheelScroll.children.length : 0
+      if (currentChildrenCount !== this.childrenCount) {
+        this.childrenCount = currentChildrenCount
+        this.refresh()
+      }
+    },
+    beforeDestroy() {
+      if (this.wheel) {
+        this.wheel.destroy()
+      }
+    },
+    methods: {
+      setColumnHeight(height) {
+        for (let i = 0; i < this.$refs.wheelScroll.children.length; i++) {
+          if (this.currentIndicatorMaskHeight) {
+            this.$refs.wheelScroll.children[i].style.height = this.currentIndicatorMaskHeight + 'px'
+          }
         }
-        this.wheel = new BScroll(wheelWrapper, extend({
-          wheel: {
-            selectedIndex: this.selectedIndex[0],
-            rotate: -5,
-            wheelWrapperClass: 'wheel-scroll'
-          },
-          probeType: 3,
-          bindToWrapper: true
-        }, this.scrollOptions))
-        this.wheel.on('scrollStart', function () {
-          console.log('scrollStart=======', this.lastSelectedIndex)
-          if (this.pickerView) {
-            this.pickerView.notifyPickstart()
+      },
+      refresh() {
+        if (this.refreshing) return
+
+        this.refreshing = true
+        this.$nextTick(() => {
+          const wheelWrapper = this.$refs.wheelWrapper
+          if (this.wheel) {
+            this.wheel.refresh()
+            this.refreshing = false
+            return
           }
-        }.bind(this))
-        this.wheel.on('scrollEnd', function () {
-          console.log('scrollEnd=======', this.lastSelectedIndex)
-          if (this.refreshing) return
-          // 只更新 lastSelectedIndex，不触发 watcher
-          const actualIndex = this.wheel.getSelectedIndex()
-          this.lastSelectedIndex = [actualIndex]
-          
-          if (this.pickerView) {
-            this.pickerView.notifyChange()
-            this.pickerView.notifyPickend()
-          }
-        }.bind(this))
-        this.refreshing = false
-      })
+          this.wheel = new BScroll(wheelWrapper, extend({
+            wheel: {
+              selectedIndex: this.selectedIndex[0],
+              rotate: -5,
+              wheelWrapperClass: 'wheel-scroll'
+            },
+            probeType: 3,
+            bindToWrapper: true
+          }, this.scrollOptions))
+          this.wheel.on('scrollStart', function () {
+            if (this.pickerView) {
+              this.pickerView.notifyPickstart()
+            }
+          }.bind(this))
+          this.wheel.on('scrollEnd', function () {
+            console.log('scrollEnd', this.refreshing)
+            if (this.refreshing) return
+            if (this.pickerView) {
+              this.pickerView.notifyChange()
+              this.pickerView.notifyPickend()
+            }
+          }.bind(this))
+          this.refreshing = false
+        })
+      }
     }
   }
-}
 </script>
 
 <style scoped lang="stylus" rel="stylesheet/stylus">

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view-column.vue
@@ -30,17 +30,30 @@ export default {
       wheel: null,
       selectedIndex: [0],
       currentIndicatorMaskHeight: 0,
-      childrenCount: 0
+      childrenCount: 0,
+      lastSelectedIndex: [0]
     }
   },
   watch: {
-    selectedIndex (newVal) {
+    selectedIndex (newVal, oldVal) {
       if (this.wheel) {
-        this.$nextTick(() => {
-          // make sure the dom rendering is complete
-          this.wheel.refresh()
-          this.wheel.wheelTo(newVal[0])
-        })
+        // 获取滚轮当前实际位置
+        const currentActualIndex = this.wheel.getSelectedIndex()
+        console.log('column selectedIndex changed', newVal, 'wheel actual:', currentActualIndex)
+        
+        // 只有当新值与滚轮实际位置不同时才执行 wheelTo
+        if (newVal[0] !== currentActualIndex) {
+          console.log('wheelTo', newVal[0], 'from actual:', currentActualIndex)
+          this.lastSelectedIndex = [...newVal]
+          this.$nextTick(() => {
+            // make sure the dom rendering is complete
+            this.wheel.refresh()
+            this.wheel.wheelTo(newVal[0])
+          })
+        } else {
+          // 即使值相同，也要更新 lastSelectedIndex，保持状态同步
+          this.lastSelectedIndex = [...newVal]
+        }
       }
     },
     indicatorMaskHeight: {
@@ -97,12 +110,18 @@ export default {
           bindToWrapper: true
         }, this.scrollOptions))
         this.wheel.on('scrollStart', function () {
+          console.log('scrollStart=======', this.lastSelectedIndex)
           if (this.pickerView) {
             this.pickerView.notifyPickstart()
           }
         }.bind(this))
         this.wheel.on('scrollEnd', function () {
+          console.log('scrollEnd=======', this.lastSelectedIndex)
           if (this.refreshing) return
+          // 只更新 lastSelectedIndex，不触发 watcher
+          const actualIndex = this.wheel.getSelectedIndex()
+          this.lastSelectedIndex = [actualIndex]
+          
           if (this.pickerView) {
             this.pickerView.notifyChange()
             this.pickerView.notifyPickend()

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script type="text/ecmascript-6">
+  import { computed } from 'vue'
   import {getCustomEvent} from './getInnerListeners'
 
   function travelSlot(slot, effect) {
@@ -42,23 +43,40 @@
       maskStyle: String,
       maskClass: String
     },
-    data() {
+    provide() {
       return {
-        maskHeight: 0
+        indicatorMaskHeight: computed(() => this.indicatorMaskHeight || 0)
       }
     },
-    computed: {},
+    data() {
+      return {
+        maskHeight: 0,
+        indicatorMaskHeight: 0
+      }
+    },
     watch: {
       value: {
         handler(newVal) {
           this.setValue(newVal)
         }
+      },
+      indicatorStyle: {
+        handler() {
+          this.$nextTick(() => {
+            this.updateIndicatorMaskHeight()
+          })
+        }
+      },
+      indicatorClass: {
+        handler() {
+          this.$nextTick(() => {
+            this.updateIndicatorMaskHeight()
+          })
+        }
       }
     },
     mounted() {
-      let containerHeight = this.$refs.mpxView.offsetHeight
-      let indicatorMaskHeight = this.$refs.indicatorMask.offsetHeight
-      this.maskHeight = (containerHeight - indicatorMaskHeight) / 2
+      this.updateIndicatorMaskHeight()
       if (this.value) {
         this.setValue(this.value)
       } else {
@@ -104,6 +122,11 @@
       },
       notifyPickend() {
         this.$emit('pickend', getCustomEvent('pickend', {}, this))
+      },
+      updateIndicatorMaskHeight() {
+        let containerHeight = this.$refs.mpxView.offsetHeight
+        this.indicatorMaskHeight = this.$refs.indicatorMask.offsetHeight
+        this.maskHeight = (containerHeight - this.indicatorMaskHeight) / 2
       }
     }
   }

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view.vue
@@ -108,7 +108,7 @@
             if (!component.pickerView) {
               component.pickerView = this
             }
-            value.push(this.$children[i].wheels[0] && this.$children[i].wheels[0].getSelectedIndex() || 0)
+            value.push(this.$children[i].wheel && this.$children[i].wheel.getSelectedIndex() || 0)
           }
         })
         return value

--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-picker-view.vue
@@ -59,7 +59,7 @@
     watch: {
       value: {
         handler(newVal) {
-          console.log('column set value==', newVal)
+          // console.log('column set value', newVal)
           this.setValue(newVal)
         },
         deep: true
@@ -89,7 +89,7 @@
     },
     methods: {
       setValue(value) {
-        console.log('setValue called with:', value)
+        // console.log('setValue called with:', value)
         // 标记这是外部更新，计算需要wheelTo的列数
         this.isExternalUpdate = true
         this.pendingWheelToCount = 0
@@ -104,7 +104,7 @@
           }
         })
 
-        console.log('setValue pendingWheelToCount:', this.pendingWheelToCount)
+        // console.log('setValue pendingWheelToCount:', this.pendingWheelToCount)
 
         // 直接遍历 $children，更新值
         this.$children.forEach((child, i) => {
@@ -113,8 +113,8 @@
               child.pickerView = this
             }
             if (value[i] !== undefined) {
-              console.log('updating column', i, 'from', child.selectedIndex[0], 'to', value[i])
-              child.selectedIndex.splice(0, 1, value[i])
+              // console.log('updating column', i, 'from', child.selectedIndex, 'to', value[i])
+              this.$set(child, 'selectedIndex', value[i])
             }
           }
         })
@@ -139,11 +139,11 @@
       notifyChange() {
         // 如果是外部更新引起的滚动，不触发 change 事件
         if (this.isExternalUpdate) {
-          console.log('skip notifyChange during external update')
+          // console.log('skip notifyChange during external update')
           return
         }
         const value = this.getValue()
-        console.log('notifyChange column', value)
+        // console.log('notifyChange column', value)
         this.$emit('change', getCustomEvent('change', { value }, this))
       },
       notifyPickstart() {
@@ -159,17 +159,17 @@
       },
       onWheelToComplete() {
         this.pendingWheelToCount = this.pendingWheelToCount - 1
-        console.log('wheelTo complete, remaining:', this.pendingWheelToCount)
+        // console.log('wheelTo complete, remaining:', this.pendingWheelToCount)
 
         // 所有 wheelTo 都完成了，触发 change 事件并重置状态
         if (this.pendingWheelToCount <= 0) {
           this.isExternalUpdate = false
-          console.log('all wheelTo completed, external update finished')
+          // console.log('all wheelTo completed, external update finished')
 
           // 外部更新完成后，触发一次 change 事件
           const value = this.getValue()
           this.$emit('change', getCustomEvent('change', { value }, this))
-          console.log('external update change event:', value)
+          // console.log('external update change event:', value)
         }
       }
     }


### PR DESCRIPTION
1. 修改 picker-view 设置 value 值后 change 事件的触发逻辑
2. 修改 picker-view-column 的子组件样式更新逻辑，由原来 refresh 方法中更新改为只在 indicatorMaskHeight 高度变时更新
3. updated 钩子触发时，新增判断条件，满足再执行 refresh