### PR TITLE
feat: 支持rnConfig.customDimensionsInfo自定义Mpx窗口尺寸信息

### DIFF
--- a/packages/core/src/platform/builtInMixins/styleHelperMixin.ios.js
+++ b/packages/core/src/platform/builtInMixins/styleHelperMixin.ios.js
@@ -15,8 +15,8 @@ let width, height
 function customDimensionsInfo (dimensions) {
   if (typeof Mpx.config.rnConfig?.customDimensionsInfo === 'function') {
     dimensionsInfo = Mpx.config.rnConfig.customDimensionsInfo(dimensions) || dimensions
-    width = dimensionsInfo.window.width
-    height = dimensionsInfo.window.height
+    width = dimensionsInfo.screen.width
+    height = dimensionsInfo.screen.height
   }
 }
 


### PR DESCRIPTION
rnConfig.customDimensionsInfo用于控制mpx样式渲染使用的窗口尺寸信息，如在折叠屏下可将width / 2 得到半屏渲染的效果，例如
```
mpx.config.rnConfig.customDimensionsInfo = function(dimensionsInfo) {
    const screen = dimensionsInfo.screen
    const isLargeFoldableLike = (__mpx_mode__ === 'android') && (screen.height / screen.width < 1.5) && (screen.width > 600)
    if (isLargeFoldableLike) screen.width = screen.width / 2
    return dimensionsInfo
}
```