### PR TITLE
fix: 修复windows下替换wx为mpx runtime逻辑异常

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -1606,7 +1606,8 @@ class MpxWebpackPlugin {
               target = expr.object
             }
 
-            if (!matchCondition(resourcePath, this.options.transMpxRules) || resourcePath.indexOf('node_modules/@mpxjs') !== -1 || !target || mode === srcMode) return
+            const mpxjsPath = path.join('node_modules', '@mpxjs') // 适配不同系统下路径格式不同
+            if (!matchCondition(resourcePath, this.options.transMpxRules) || resourcePath.indexOf(mpxjsPath) !== -1 || !target || mode === srcMode) return
 
             const type = target.name
             const name = type === 'wx' ? 'mpx' : 'createFactory'

--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -1606,8 +1606,7 @@ class MpxWebpackPlugin {
               target = expr.object
             }
 
-            const mpxjsPath = path.join('node_modules', '@mpxjs') // 适配不同系统下路径格式不同
-            if (!matchCondition(resourcePath, this.options.transMpxRules) || resourcePath.indexOf(mpxjsPath) !== -1 || !target || mode === srcMode) return
+            if (!matchCondition(resourcePath, this.options.transMpxRules) || toPosix(resourcePath).indexOf('node_modules/@mpxjs') !== -1 || !target || mode === srcMode) return
 
             const type = target.name
             const name = type === 'wx' ? 'mpx' : 'createFactory'


### PR DESCRIPTION
windows路径使用\分隔导致mpxjs中getEnvObj中的wx被替换为mpx，出现循环依赖