### PR TITLE
fix: 修复选项式api下生命周期中getCurrentInstance为空问题

### DIFF
--- a/packages/core/src/core/proxy.js
+++ b/packages/core/src/core/proxy.js
@@ -170,7 +170,7 @@ export default class MpxProxy {
     }
     if (!isWeb) {
       // web中BEFORECREATE钩子通过vue的beforeCreate钩子单独驱动
-      this.callHook(BEFORECREATE, undefined, false, false)
+      this.callHook(BEFORECREATE)
       setCurrentInstance(this)
       this.parent = this.resolveParent()
       this.provides = this.parent ? this.parent.provides : Object.create(null)
@@ -496,25 +496,24 @@ export default class MpxProxy {
     }
   }
 
-  callHook (hookName, params, hooksOnly, setContext = true) {
+  callHook (hookName, params, hooksOnly) {
     const hook = this.options[hookName]
     const hooks = this.hooks[hookName] || []
-    const prevCurrentInstance = getCurrentInstance()
     let result
-    if (prevCurrentInstance !== this && setContext) {
-      setCurrentInstance(this)
-    }
     if (isFunction(hook) && !hooksOnly) {
+      const setContext = hookName !== BEFORECREATE
+      if (setContext) {
+        setCurrentInstance(this)
+      }
       result = callWithErrorHandling(hook.bind(this.target), this, `${hookName} hook`, params)
+      if (setContext) {
+        unsetCurrentInstance()
+      }
     }
     hooks.forEach((hook) => {
       result = params ? hook(...params) : hook()
     })
 
-    if (setContext && prevCurrentInstance !== this) {
-      if (prevCurrentInstance) setCurrentInstance(prevCurrentInstance)
-      else unsetCurrentInstance()
-    }
     return result
   }
 

--- a/packages/core/src/platform/patch/getDefaultOptions.web.js
+++ b/packages/core/src/platform/patch/getDefaultOptions.web.js
@@ -39,10 +39,10 @@ function filterOptions (options) {
 function initProxy (context, rawOptions) {
   if (!context.__mpxProxy) {
     context.__mpxProxy = new MpxProxy(rawOptions, context)
-    context.__mpxProxy.callHook(BEFORECREATE)
+    context.__mpxProxy.callHook(BEFORECREATE, undefined, false, false)
   } else if (context.__mpxProxy.isUnmounted()) {
     context.__mpxProxy = new MpxProxy(rawOptions, context, true)
-    context.__mpxProxy.callHook(BEFORECREATE)
+    context.__mpxProxy.callHook(BEFORECREATE, undefined, false, false)
   }
 }
 

--- a/packages/core/src/platform/patch/getDefaultOptions.web.js
+++ b/packages/core/src/platform/patch/getDefaultOptions.web.js
@@ -39,10 +39,10 @@ function filterOptions (options) {
 function initProxy (context, rawOptions) {
   if (!context.__mpxProxy) {
     context.__mpxProxy = new MpxProxy(rawOptions, context)
-    context.__mpxProxy.callHook(BEFORECREATE, undefined, false, false)
+    context.__mpxProxy.callHook(BEFORECREATE)
   } else if (context.__mpxProxy.isUnmounted()) {
     context.__mpxProxy = new MpxProxy(rawOptions, context, true)
-    context.__mpxProxy.callHook(BEFORECREATE, undefined, false, false)
+    context.__mpxProxy.callHook(BEFORECREATE)
   }
 }
 


### PR DESCRIPTION
与Vue表现拉齐，选项式 Api 生命周期中依然可通过 getCurrentInstance 获取当前组件实例