### PR TITLE
fix: 修复mode/env resolver可能导致模块重复输出问题

### DIFF
--- a/packages/webpack-plugin/lib/resolver/AddEnvPlugin.js
+++ b/packages/webpack-plugin/lib/resolver/AddEnvPlugin.js
@@ -16,6 +16,8 @@ module.exports = class AddEnvPlugin {
   apply (resolver) {
     const target = resolver.ensureHook(this.target)
     const env = this.env
+    const envPattern = new RegExp(`\\.${env}(\\.|$)`)
+
     resolver.getHook(this.source).tapAsync('AddEnvPlugin', (request, resolveContext, callback) => {
       if (request.env) {
         return callback()
@@ -32,11 +34,34 @@ module.exports = class AddEnvPlugin {
       }
       // 当前资源没有后缀名或者路径不符合fileConditionRules规则时，直接返回
       if (!extname || !matchCondition(resourcePath, this.fileConditionRules)) return callback()
+
       const queryObj = parseQuery(request.query || '?')
-      queryObj.infix = `${queryObj.infix || ''}.${env}`
+      let infix = `${queryObj.infix || ''}.${env}`
+
+      if (envPattern.test(path.basename(resourcePath))) {
+        /**
+         * 为解决同时存在 import 'index' / 'index.mode.env' 时
+         * 产物中出现重复的 index.mode.env 与 index.mode.env?infix=.mode.env
+         * 会对所有resourcePath包含.mode的模块加上infix=.mode，对所有resourcePath包含.env的模块加上infix=.env
+         * 这将导致 index.env.mode（注意此处env与mode对位置不对）也会被加上infix=.mode.env（.mode总是先于.env添加上，所以一定是.mode在前）
+         *
+         * 所以此处需对infix进行修正，确保infix与resourcePath文件名中一致
+         */
+        // 如果 infix 无法与文件名匹配，则说明infix中 .env 位置不对，需要把 .env 放到最前面
+        if (!path.basename(resourcePath).includes(infix)) {
+          infix = `.${env}${queryObj.infix || ''}`
+        }
+        queryObj.infix = infix
+        request.query = stringifyQuery(queryObj)
+        request.env = obj.env
+        return callback()
+      }
+
+      queryObj.infix = infix
       obj.query = stringifyQuery(queryObj)
       obj.path = addInfix(resourcePath, env, extname)
       obj.relativePath = request.relativePath && addInfix(request.relativePath, env, extname)
+
       resolver.doResolve(target, Object.assign({}, request, obj), 'add env: ' + env, resolveContext, callback)
     })
   }

--- a/packages/webpack-plugin/lib/resolver/AddModePlugin.js
+++ b/packages/webpack-plugin/lib/resolver/AddModePlugin.js
@@ -17,6 +17,8 @@ module.exports = class AddModePlugin {
     const target = resolver.ensureHook(this.target)
     const { options = {}, mode } = this
     const { defaultMode, fileConditionRules, implicitMode } = options
+    const modePattern = new RegExp(`\\.${mode}(\\.|$)`)
+
     resolver.getHook(this.source).tapAsync('AddModePlugin', (request, resolveContext, callback) => {
       if (request.mode || request.env) {
         return callback()
@@ -33,13 +35,23 @@ module.exports = class AddModePlugin {
       }
       // 当前资源没有后缀名或者路径不符合fileConditionRules规则时，直接返回
       if (!extname || !matchCondition(resourcePath, fileConditionRules)) return callback()
+
       const queryObj = parseQuery(request.query || '?')
       const queryInfix = queryObj.infix
       if (!implicitMode) queryObj.mode = mode
       queryObj.infix = `${queryInfix || ''}.${mode}`
       obj.query = stringifyQuery(queryObj)
+
+      if (modePattern.test(resourcePath)) {
+        // 如果已经确认是mode后缀的文件，添加query与mode后直接返回
+        request.query = obj.query
+        request.mode = obj.mode
+        return callback()
+      }
+
       obj.path = addInfix(resourcePath, mode, extname)
       obj.relativePath = request.relativePath && addInfix(request.relativePath, mode, extname)
+
       resolver.doResolve(target, Object.assign({}, request, obj), 'add mode: ' + mode, resolveContext, (err, result) => {
         if (defaultMode && !result) {
           queryObj.infix = `${queryInfix || ''}.${defaultMode}`


### PR DESCRIPTION
**问题：**

当同时存在 `import 'index'` 与 `import 'index.mode'` 时，`import 'index'` 会经过自定义 resolver 定向到 `index.mode` 并添加 query。
添加 query 后 webpack 会认为 `index.mode?query` 与 `index.mode` 为不同模块，造成产物中模块内容重复

**例子：**
```
common
├── test1.js
├── test1.wx.js
├── test2.didi.js
├── test2.js
├── test3.js
├── test3.wx.didi.js
├── test3.wx.js
└── test4.didi.wx.js
```

```js
import './common/test1'
import './common/test1.js'
import './common/test1.wx'
import './common/test1.wx.js'

import './common/test2'
import './common/test2.js'
import './common/test2.didi'
import './common/test2.didi.js'

import './common/test3'
import './common/test3.js'
import './common/test3.wx.didi'
import './common/test3.wx.didi.js'

import './common/test4.didi.wx.js'
```

修复前输出产物：其中 `./src/common/test1.wx.js?infix=.wx&mode=wx` 与 `./src/common/test1.wx.js` 模块内容一致。
```js
__webpack_require__("./src/common/test1.wx.js?infix=.wx&mode=wx");
__webpack_require__("./src/common/test1.wx.js");
__webpack_require__("./src/common/test2.didi.js?infix=.didi");
__webpack_require__("./src/common/test2.didi.js");
__webpack_require__("./src/common/test3.wx.didi.js?infix=.wx.didi&mode=wx");
__webpack_require__("./src/common/test3.wx.didi.js");
__webpack_require__("./src/common/test4.didi.wx.js");
```


修复后输出产物：
```js
__webpack_require__("./src/common/test1.wx.js?infix=.wx&mode=wx");
__webpack_require__("./src/common/test2.didi.js?infix=.didi");
__webpack_require__("./src/common/test3.wx.didi.js?infix=.wx.didi&mode=wx");
__webpack_require__("./src/common/test4.didi.wx.js?infix=.didi.wx&mode=wx");
```

**修复方案:**
在自定义resolver中，判定如果文件路径本身存在 .mode 中缀或后缀，则直接添加对应query并不再尝试查找 .mode.mode。
env resolver同理