### PR TITLE
fix focus早用业务上触发事件后执行的blur事件的问题

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/web/mpx-input.vue
+++ b/packages/webpack-plugin/lib/runtime/components/web/mpx-input.vue
@@ -60,9 +60,9 @@
       focus: {
         handler (val) {
           if (val) {
-            this.$nextTick(() => {
+            setTimeout(() => { // 处理用户如果在blur事件回调里面设置传入focus的值会有执行时差，晚于当前执行，所以改成setTimeout
               this.$refs.input.focus()
-            })
+            }, 0)
           } else {
             this.$nextTick(() => {
               this.$refs.input.blur()


### PR DESCRIPTION
问题： 业务上如果想要在失去焦点回设这个focus得值会有时差问题，blur晚于获取焦点的这个处理执行，导致表现是获取焦点后立马失去焦点，不符合业务预期