### PR TITLE
fix: 修复输出RN style传递对象时出现非预期样式

### DIFF
--- a/packages/core/src/platform/builtInMixins/styleHelperMixin.ios.js
+++ b/packages/core/src/platform/builtInMixins/styleHelperMixin.ios.js
@@ -223,7 +223,7 @@ export default function styleHelperMixin () {
               mergeResult(staticStyle)
             }
           } else {
-            Object.assign(styleObj, normalizeDynamicStyle(staticStyle))
+            Object.assign(styleObj, parseStyleText(staticStyle))
           }
           Object.assign(styleObj, normalizeDynamicStyle(dynamicStyle))
           mergeResult(transformStyleObj(styleObj))

--- a/packages/utils/src/base.js
+++ b/packages/utils/src/base.js
@@ -82,6 +82,9 @@ const hasProto = '__proto__' in {}
 function cached (fn) {
   const cache = Object.create(null)
   return function cachedFn (str) {
+    if (typeof str !== 'string') {
+      return fn(str)
+    }
     const hit = cache[str]
     return hit || (cache[str] = fn(str))
   }


### PR DESCRIPTION
cached 函数在传入引用类型的参数时，缓存的key将会被序列化为重复的 Object 字符串，cached不应缓存非引用类型的参数