### PR TITLE
fix(rn): optimize keyboard to prevent animation conflicts

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-keyboard-avoiding-view.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-keyboard-avoiding-view.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode, useContext, useEffect } from 'react'
+import React, { ReactNode, useContext, useEffect, useRef } from 'react'
 import { DimensionValue, EmitterSubscription, Keyboard, View, ViewStyle, NativeSyntheticEvent, NativeTouchEvent } from 'react-native'
-import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated'
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing, cancelAnimation } from 'react-native-reanimated'
 import { KeyboardAvoidContext } from './context'
 import { isIOS } from './utils'
 
@@ -18,15 +18,30 @@ const KeyboardAvoidingView = ({ children, style, contentContainerStyle }: Keyboa
   const basic = useSharedValue('auto')
   const keyboardAvoid = useContext(KeyboardAvoidContext)
 
+  // fix: 某些特殊机型下隐藏键盘可能会先触发一次 keyboardWillShow，
+  // 比如机型 iPhone 11 Pro，可能会导致显隐动画冲突
+  // 因此增加状态标记 + clearTimeout + cancelAnimation 来优化
+  const isShow = useRef<boolean>(false)
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: -offset.value }],
     flexBasis: basic.value as DimensionValue
   }))
 
   const resetKeyboard = () => {
+    if (!isShow.current) {
+      return
+    }
+
+    isShow.current = false
+    timerRef.current && clearTimeout(timerRef.current)
+
     if (keyboardAvoid?.current) {
       keyboardAvoid.current = null
     }
+
+    cancelAnimation(offset)
     offset.value = withTiming(0, { duration, easing })
     basic.value = 'auto'
   }
@@ -43,15 +58,23 @@ const KeyboardAvoidingView = ({ children, style, contentContainerStyle }: Keyboa
     if (isIOS) {
       subscriptions = [
         Keyboard.addListener('keyboardWillShow', (evt: any) => {
-          if (!keyboardAvoid?.current) return
+          if (!keyboardAvoid?.current || isShow.current) {
+            return
+          }
+
+          isShow.current = true
+          timerRef.current && clearTimeout(timerRef.current)
+
           const { endCoordinates } = evt
           const { ref, cursorSpacing = 0 } = keyboardAvoid.current
-          setTimeout(() => {
+
+          timerRef.current = setTimeout(() => {
             ref?.current?.measure((x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
               const aboveOffset = offset.value + pageY + height - endCoordinates.screenY
               const aboveValue = -aboveOffset >= cursorSpacing ? 0 : aboveOffset + cursorSpacing
               const belowValue = Math.min(endCoordinates.height, aboveOffset + cursorSpacing)
               const value = aboveOffset > 0 ? belowValue : aboveValue
+              cancelAnimation(offset)
               offset.value = withTiming(value, { duration, easing }, (finished) => {
                 if (finished) {
                   // Set flexBasic after animation to trigger re-layout and reset layout information
@@ -66,15 +89,22 @@ const KeyboardAvoidingView = ({ children, style, contentContainerStyle }: Keyboa
     } else {
       subscriptions = [
         Keyboard.addListener('keyboardDidShow', (evt: any) => {
-          if (!keyboardAvoid?.current) return
+          if (!keyboardAvoid?.current || isShow.current) {
+            return
+          }
+
+          isShow.current = true
+
           const { endCoordinates } = evt
           const { ref, cursorSpacing = 0 } = keyboardAvoid.current
+
           ref?.current?.measure((x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
             const aboveOffset = pageY + height - endCoordinates.screenY
             const belowOffset = endCoordinates.height - aboveOffset
             const aboveValue = -aboveOffset >= cursorSpacing ? 0 : aboveOffset + cursorSpacing
             const belowValue = Math.min(belowOffset, cursorSpacing)
             const value = aboveOffset > 0 ? belowValue : aboveValue
+            cancelAnimation(offset)
             offset.value = withTiming(value, { duration, easing }, (finished) => {
               if (finished) {
                 // Set flexBasic after animation to trigger re-layout and reset layout information
@@ -89,6 +119,7 @@ const KeyboardAvoidingView = ({ children, style, contentContainerStyle }: Keyboa
 
     return () => {
       subscriptions.forEach(subscription => subscription.remove())
+      timerRef.current && clearTimeout(timerRef.current)
     }
   }, [keyboardAvoid])
 


### PR DESCRIPTION
## Fix
- 某些特殊机型下隐藏键盘可能会先触发一次 `keyboardWillShow`，比如机型 iPhone 11 Pro，可能会导致显隐动画冲突。防止未来可能的类似冲突，增加状态标记 `isShow` + `clearTimeout` + `cancelAnimation` 来优化。