### PR TITLE
feat: input 新增支持keyboard-type属性

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-input.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-input.tsx
@@ -95,16 +95,16 @@ export interface InputProps {
   'selection-start'?: number
   'selection-end'?: number
   'placeholder-style'?: { color?: string }
-  'enable-offset'?: boolean,
+  'enable-offset'?: boolean
   'enable-var'?: boolean
   'external-var-context'?: Record<string, any>
   'parent-font-size'?: number
   'parent-width'?: number
   'parent-height'?: number
   // 只有 RN 环境读取
-  'keyboard-type'?: string,
-  'adjust-position': boolean,
-  'hold-keyboard'?: boolean,
+  'keyboard-type'?: string
+  'adjust-position': boolean
+  'hold-keyboard'?: boolean
   bindinput?: (evt: NativeSyntheticEvent<TextInputTextInputEventData> | unknown) => void
   bindfocus?: (evt: NativeSyntheticEvent<TextInputFocusEventData> | unknown) => void
   bindblur?: (evt: NativeSyntheticEvent<TextInputFocusEventData> | unknown) => void


### PR DESCRIPTION
基于微信小程序规范维护的 keyboardTypeMap 可能无法满足需求，现调整为优先读取 RN 支持的 keyboard-type，未匹配时再回退至 keyboardTypeMap。