### PR TITLE
fix: 修复切换聚焦输入框意外失焦问题

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/react/context.ts
+++ b/packages/webpack-plugin/lib/runtime/components/react/context.ts
@@ -12,6 +12,7 @@ export type KeyboardAvoidContextValue = MutableRefObject<{
   adjustPosition: boolean
   keyboardHeight?: number
   onKeyboardShow?: () => void
+  readyToShow?: boolean
 } | null>
 
 export interface GroupValue {

--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-input.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-input.tsx
@@ -283,7 +283,7 @@ const Input = forwardRef<HandlerRef<TextInput, FinalInputProps>, FinalInputProps
 
   const setKeyboardAvoidContext = () => {
     if (keyboardAvoid) {
-      keyboardAvoid.current = { cursorSpacing, ref: nodeRef, adjustPosition }
+      keyboardAvoid.current = { cursorSpacing, ref: nodeRef, adjustPosition, readyToShow: true }
     }
   }
 

--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-keyboard-avoiding-view.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-keyboard-avoiding-view.tsx
@@ -41,8 +41,9 @@ const KeyboardAvoidingView = ({ children, style, contentContainerStyle }: Keyboa
 
     if (keyboardAvoid?.current) {
       const inputRef = keyboardAvoid.current.ref?.current
-      if (inputRef && inputRef.isFocused()) {
+      if (inputRef && inputRef.isFocused() && !keyboardAvoid.current.readyToShow) {
         // 修复 Android 点击键盘收起按钮时当前 input 没触发失焦的问题
+        // keyboardAvoid.current.readyToShow = true 表示聚焦到了新的输入框，不需要手动触发失焦
         inputRef.blur()
       }
       if (!keyboardAvoid.current.onKeyboardShow) {
@@ -65,6 +66,10 @@ const KeyboardAvoidingView = ({ children, style, contentContainerStyle }: Keyboa
     let subscriptions: EmitterSubscription[] = []
 
     function keybaordAvoding(evt: any, ios = false) {
+      if (keyboardAvoid?.current?.readyToShow) {
+        // 重置标记位
+        keyboardAvoid.current.readyToShow = false
+      }
       if (!keyboardAvoid?.current || isShow.current) {
         return
       }


### PR DESCRIPTION
## Fix(RN)

- 安卓机型，从一个聚焦状态的输入框，点击聚焦到另一个输入框，可能会导致新输入框的意外失焦