### PR TITLE
fix: 修复热更新后屏幕大小变化无法正常触发rpx重新渲染

### DIFF
--- a/packages/core/src/platform/builtInMixins/styleHelperMixin.ios.js
+++ b/packages/core/src/platform/builtInMixins/styleHelperMixin.ios.js
@@ -33,7 +33,12 @@ function getPageSize (window = global.__mpxAppDimensionsInfo.screen) {
   return window.width + 'x' + window.height
 }
 
-Dimensions.addEventListener('change', ({ window, screen }) => {
+if (global.__mpxDimensionChangeSubscription) {
+  // 适配热更新场景，清除旧的监听，避免重复触发
+  global.__mpxDimensionChangeSubscription.remove()
+}
+
+global.__mpxDimensionChangeSubscription = Dimensions.addEventListener('change', ({ window, screen }) => {
   const oldScreen = getPageSize(global.__mpxAppDimensionsInfo.screen)
   useDimensionsInfo({ window, screen })
 

--- a/packages/core/src/platform/patch/getDefaultOptions.ios.js
+++ b/packages/core/src/platform/patch/getDefaultOptions.ios.js
@@ -399,6 +399,8 @@ function usePageEffect (mpxProxy, pageId) {
     const hasShowHook = hasPageHook(mpxProxy, [ONSHOW, 'show'])
     const hasHideHook = hasPageHook(mpxProxy, [ONHIDE, 'hide'])
     const hasResizeHook = hasPageHook(mpxProxy, [ONRESIZE, 'resize'])
+    const currentCountMap = global.__mpxPageSizeCountMap
+
     if (hasShowHook || hasHideHook || hasResizeHook) {
       if (hasOwn(pageStatusMap, pageId)) {
         unWatch = watch(() => pageStatusMap[pageId], (newVal) => {
@@ -420,7 +422,10 @@ function usePageEffect (mpxProxy, pageId) {
     }
     return () => {
       unWatch && unWatch()
-      del(global.__mpxPageSizeCountMap, pageId)
+      // 兼容热更新场景下，旧页面的删除时机可能晚与新页面创建时机，再次删除前需判断global.__mpxPageSizeCountMap未发生变化
+      if (global.__mpxPageSizeCountMap === currentCountMap) {
+        del(global.__mpxPageSizeCountMap, pageId)
+      }
     }
   }, [])
 }


### PR DESCRIPTION
问题1: 热更新下文件会被重载，将导致Dimensions.addEventListener被执行多次
问题2: 热更新下旧页面的销毁时间晚与新页面的创建时机，在旧页面的销毁回调中对global的相关操作需要做好处理，避免操作到新页面的内容。


原生RN开发下使用module.hot.dispose绑定当前文件被热更新重载的回调，但经过webpack编译后module关键字被webpack修改为一个新对象来完成模块之间的隔离，而不是整个bundle的module对象。

继续使用module.hot.dispose方式来处理热更新需修改webpack编译，成本较大。
改为借助热更新前后 global 对象不变的特性来判断当前文件是否被重载