### PR TITLE
fix onload传参空的情况

### DIFF
--- a/packages/core/src/platform/patch/getDefaultOptions.ios.js
+++ b/packages/core/src/platform/patch/getDefaultOptions.ios.js
@@ -315,7 +315,7 @@ function createInstance ({ propsRef, type, rawOptions, currentInject, validProps
   if (type === 'page') {
     const props = propsRef.current
     const decodedQuery = {}
-    const rawQuery = props.route.params
+    const rawQuery = props.route.params || {}
     if (isObject(rawQuery)) {
       for (const key in rawQuery) {
         decodedQuery[key] = decodeURIComponent(rawQuery[key])


### PR DESCRIPTION
如果跳转的时候没有拼接参数，在透传onload的时候要给业务传{}做兜底