### PR TITLE
修复unocss-plugin中某些平台mpxConfig没有typeExtMap字段导致HookWebpackError的问题

### DIFF
--- a/packages/unocss-plugin/lib/index.js
+++ b/packages/unocss-plugin/lib/index.js
@@ -304,7 +304,7 @@ class MpxUnocssPlugin {
           assets[file] = getRawSource(output)
         }
         // 处理wxml
-        const { template: templateExt, styles: styleExt } = mpxConfig[mode].typeExtMap
+        const { template: templateExt, styles: styleExt } = mpxConfig[mode].typeExtMap || {}
         const packageClassesMaps = {
           main: {}
         }


### PR DESCRIPTION
HookWebpackError: Cannot destructure property 'template' of 'mpxConfig[mode].typeExtMap' as it is undefined.

一些使用reactConfig的平台在build且使用了unocss-plugin时因缺少typeExtMap导致打包异常，本次提交进行空值兼容防止打包失败。
