### PR TITLE
fix: 修复红米&魅族手机的底部虚拟按键计算错误的问题

### DIFF
--- a/packages/core/src/platform/env/navigationHelper.ios.js
+++ b/packages/core/src/platform/env/navigationHelper.ios.js
@@ -1,7 +1,7 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { NavigationContainer, StackActions } from '@react-navigation/native'
 import PortalHost from '@mpxjs/webpack-plugin/lib/runtime/components/react/dist/mpx-portal/portal-host'
-import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context'
+import { SafeAreaProvider, useSafeAreaInsets, initialWindowMetrics } from 'react-native-safe-area-context'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 
 export {
@@ -11,5 +11,6 @@ export {
   GestureHandlerRootView,
   PortalHost,
   SafeAreaProvider,
-  useSafeAreaInsets
+  useSafeAreaInsets,
+  initialWindowMetrics
 }

--- a/packages/core/src/platform/patch/getDefaultOptions.ios.js
+++ b/packages/core/src/platform/patch/getDefaultOptions.ios.js
@@ -16,7 +16,7 @@ import {
   ProviderContext,
   RouteContext
 } from '@mpxjs/webpack-plugin/lib/runtime/components/react/dist/context'
-import { PortalHost, useSafeAreaInsets } from '../env/navigationHelper'
+import { PortalHost, useSafeAreaInsets, initialWindowMetrics } from '../env/navigationHelper'
 import { useInnerHeaderHeight } from '@mpxjs/webpack-plugin/lib/runtime/components/react/dist/mpx-nav'
 
 function getSystemInfo () {
@@ -506,7 +506,17 @@ function getLayoutData (headerHeight) {
   // 在横屏状态下 screen.height = window.height + bottomVirtualHeight
   // 在正常状态   screen.height =  window.height + bottomVirtualHeight + statusBarHeight
   const isLandscape = screenDimensions.height < screenDimensions.width
-  const bottomVirtualHeight = isLandscape ? screenDimensions.height - windowDimensions.height : ((screenDimensions.height - windowDimensions.height - ReactNative.StatusBar.currentHeight) || 0)
+  // const bottomVirtualHeight = isLandscape ? screenDimensions.height - windowDimensions.height : ((screenDimensions.height - windowDimensions.height - ReactNative.StatusBar.currentHeight) || 0)
+  let bottomVirtualHeight = 0
+  // 红米手机&魅族16T手机的screen.height = windowHeight + bottomVirtualHeight 导致计算出来的底部虚拟偏少。此部分端引擎同学进行修改中
+  // mpx临时兼容 bottomVirtualHeight取 initialWindowMetrics.inset.bottom 和 反算出来的bottomVirtualHeight的更大的值
+  if (ReactNative.Platform.OS === 'android') {
+    if (isLandscape) {
+      bottomVirtualHeight = screenDimensions.height - windowDimensions.height
+    } else {
+      bottomVirtualHeight = Math.max(screenDimensions.height - windowDimensions.height - ReactNative.StatusBar.currentHeight, initialWindowMetrics?.insets?.bottom || 0, 0)
+    }
+  }
   return {
     left: 0,
     top: headerHeight,


### PR DESCRIPTION
问题：
常规手机：screen.height =  statusBarHeight + window.height + bottomVirtualHeight
红米&魅族等手机： screen.height = window.height + bottomVirtualHeight
导致通过常规手机的方式计算出来的 bottomVirtualHeight 在红米&魅族中算出来的值偏小。导致用户拿到的windowHeight等出现错误

修复方案：
1. 短期方案：取initialWindowMetrics.inset.bottom 和 反算出来的bottomVirtualHeight 里面的更大的值 来作为最终的虚拟区域高度
2. 长期方案：引擎侧对齐所有安卓手机的计算方式

疑问：
为什么不直接使用initialWindowMetrics.inset.bottom？因为在Android15手机里面，容器侧为了对齐<15调整了useSafeAreaInsets里面的返回值会影响initialWindowMetrics的值，导致在>=15手机里面的initialWindowMetrics.inset.bottom不等于虚拟按键高度