### PR TITLE
intersection ratio 和禁止四舍五入

### DIFF
--- a/packages/api-proxy/src/platform/api/create-intersection-observer/rnIntersectionObserver.js
+++ b/packages/api-proxy/src/platform/api/create-intersection-observer/rnIntersectionObserver.js
@@ -222,7 +222,7 @@ class RNIntersectionObserver {
             // index: index,
             id: this.observerRefs[index].getNodeInstance().props?.current?.id,
             dataset: this.observerRefs[index].getNodeInstance().props?.current?.dataset || {},
-            intersectionRatio: Math.round(intersectionRatio * 100) / 100,
+            intersectionRatio,
             intersectionRect,
             boundingClientRect: observeRect,
             relativeRect: relativeRect,


### PR DESCRIPTION
当观察对象较小 & 露出比例较小时，四舍五入会导致进入时ratio为0，和退出ratio 0相同，无法区分是否被观测到