### PR TITLE
fix(input): 修复输入框特定失焦场景

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-input.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-input.tsx
@@ -285,7 +285,10 @@ const Input = forwardRef<HandlerRef<TextInput, FinalInputProps>, FinalInputProps
 
   const setKeyboardAvoidContext = () => {
     if (keyboardAvoid) {
-      keyboardAvoid.current = { cursorSpacing, ref: nodeRef, adjustPosition, holdKeyboard, readyToShow: true }
+      // readyToShow 仅在从另一个输入框切换聚焦时为 true（ref 不同），
+      // 避免同一个输入框重复调用（onTouchStart + useEffect）或单次聚焦时误设为 true 导致无法正常失焦
+      const readyToShow = !!(keyboardAvoid.current && keyboardAvoid.current.ref !== nodeRef)
+      keyboardAvoid.current = { cursorSpacing, ref: nodeRef, adjustPosition, holdKeyboard, readyToShow }
     }
   }
 


### PR DESCRIPTION
This pull request makes a targeted improvement to the `Input` component's keyboard avoidance logic. The main change ensures that the `readyToShow` flag is only set to `true` when switching focus between different input fields, preventing issues with repeated calls or incorrect focus behavior.

Keyboard avoidance logic improvement:

* Updated the `setKeyboardAvoidContext` function in `mpx-input.tsx` to set `readyToShow` only when the focused input is different from the previous one, improving focus handling and preventing bugs with repeated or single focus events.