### PR TITLE
fix: 修复typescript5 mapMutations推导错误

### DIFF
--- a/packages/store/@types/index.d.ts
+++ b/packages/store/@types/index.d.ts
@@ -294,7 +294,7 @@ export interface IStoreWithThis<S = {}, G = {}, M = {}, A = {}, D extends Deps =
     [I in keyof T]: (...payloads: any[]) => any
   }
 
-  mapMutations<K extends keyof M>(maps: K[]): Pick<M, K>
+  mapMutations<Maps extends readonly (keyof M)[]>(maps: [...Maps]): { [P in Maps[number]]: M[P] }
   mapMutations<T extends string, P extends string>(depPath: P, maps: readonly T[]): {
     [K in T]: CombineStringKey<P, K> extends keyof GetAllDepsType<M, D, 'mutations'> ? GetAllDepsType<M, D, 'mutations'>[CombineStringKey<P, K>] : (...payloads: any[]) => any
   }
@@ -305,7 +305,7 @@ export interface IStoreWithThis<S = {}, G = {}, M = {}, A = {}, D extends Deps =
     [I in keyof T]: (...payloads: any[]) => any
   }
 
-  mapActions<K extends keyof A>(maps: K[]): Pick<A, K>
+  mapActions<Maps extends readonly (keyof A)[]>(maps: [...Maps]): { [P in Maps[number]]: A[P] }
   mapActions<T extends string, P extends string>(depPath: P, maps: readonly T[]): {
     [K in T]: CombineStringKey<P, K> extends keyof GetAllDepsType<A, D, 'actions'> ? GetAllDepsType<A, D, 'actions'>[CombineStringKey<P, K>] : (...payloads: any[]) => any
   }


### PR DESCRIPTION
当methods中同时包含不同store的mapMutations时，如果这些store中存在相同mutations，即使在调用mapMutations时未指定，也会推导为最后一个 store 的 mutations 类型。
```ts
import { createPage } from '@mpxjs/core'

import storeA from '../store/storeA'
import storeB from '../store/storeB'


createPage({
  methods: {
    ...storeA.mapMutations(['increment']),
    ...storeB.mapMutations(['setAge']),
  },
  onReady() {
    this.increment('NewNameFromDetails')
    // 推导成了storeB中的increment方法
    // 因为`...storeB.mapMutations`写在`...storeA.mapMutations`
  }
})
```