### PR TITLE
fix: 将无值的属性在输出RN时视为true

### DIFF
--- a/packages/webpack-plugin/lib/template-compiler/gen-node-react.js
+++ b/packages/webpack-plugin/lib/template-compiler/gen-node-react.js
@@ -90,7 +90,7 @@ function genNode (node, isRoot = false) {
             if (node.attrsList.length) {
               const attrs = []
               node.attrsList && node.attrsList.forEach(({ name, value }) => {
-                const attrExp = attrExpMap[name] ? attrExpMap[name] : s(value)
+                const attrExp = attrExpMap[name] ? attrExpMap[name] : (value === undefined ? 'true' : s(value))
                 attrs.push(`${mapAttrName(name)}: ${attrExp}`)
               })
               exp += `, { ${attrs.join(', ')} }`


### PR DESCRIPTION
在输出RN编译模板时，未指定值的属性（例如`<scroll-view scroll-y>`）其值被解析为 `{"scroll-y": undefined}`。
现在，此类属性在生成的渲染函数中正确地处理为 `{"scroll-y": true}` （等价于`<scroll-view scroll-y="{{ true}}">`），与小程序布尔属性语义对齐。

具有显式值的属性（例如scroll-y="{{undefined}}"）保持不变。