### PR TITLE
feat: add 'getSystemSetting' to blacklist

### DIFF
--- a/packages/api-proxy/src/common/js/promisify.js
+++ b/packages/api-proxy/src/common/js/promisify.js
@@ -15,6 +15,7 @@ const blackList = [
   'getWindowInfo',
   'getAppBaseInfo',
   'getAppAuthorizeSetting',
+  'getSystemSetting',
   'getApiCategory',
   'postMessageToReferrerPage',
   'postMessageToReferrerMiniProgram',


### PR DESCRIPTION
[getSystemSetting](https://developers.weixin.qq.com/miniprogram/dev/api/base/system/wx.getSystemSetting.html) 作为同步方法，不能 promise 化。