### PR TITLE
fix(rn): remove statusBar options from navScreenOpts in createApp function

### DIFF
--- a/packages/core/src/platform/createApp.ios.js
+++ b/packages/core/src/platform/createApp.ios.js
@@ -215,9 +215,9 @@ export default function createApp (options) {
       global.__mpxInitialRunParams = initialParams
     }
     const navScreenOpts = {
-      headerShown: false,
-      statusBarTranslucent: Mpx.config.rnConfig.statusBarTranslucent ?? true,
-      statusBarBackgroundColor: 'transparent'
+      headerShown: false
+      // statusBarTranslucent: Mpx.config.rnConfig.statusBarTranslucent ?? true,
+      // statusBarBackgroundColor: 'transparent'
     }
 
     return createElement(SafeAreaProvider,


### PR DESCRIPTION
This pull request makes a minor adjustment to the `createApp` function in `createApp.ios.js` by commenting out the `statusBarTranslucent` and `statusBarBackgroundColor` properties in the `navScreenOpts` configuration. The only active option now is `headerShown: false`.

* Commented out `statusBarTranslucent` and `statusBarBackgroundColor` properties in the `navScreenOpts` object, leaving only `headerShown: false` active.