### PR TITLE
Fix/rn svg image extra render

### DIFF
--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-image.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-image.tsx
@@ -272,6 +272,24 @@ const Image = forwardRef<HandlerRef<RNImage, ImageProps>, ImageProps>((props, re
     }
   }
 
+  function updateImageSize (width: number, height: number) {
+    state.current.imageWidth = width
+    state.current.imageHeight = height
+    state.current.ratio = !width ? 0 : height / width
+
+    if (isWidthFixMode
+      ? state.current.viewWidth
+      : isHeightFixMode
+        ? state.current.viewHeight
+        : state.current.viewWidth && state.current.viewHeight) {
+      setRatio(state.current.ratio)
+      setImageWidth(width)
+      setImageHeight(height)
+      setViewSize(state.current.viewWidth!, state.current.viewHeight!, state.current.ratio)
+      setLoaded(true)
+    }
+  }
+
   const modeStyle: ImageStyle = useMemo(() => {
     if (noMeetCalcRule(isSvg, mode, viewWidth, viewHeight, ratio)) return {}
     switch (mode) {
@@ -370,21 +388,7 @@ const Image = forwardRef<HandlerRef<RNImage, ImageProps>, ImageProps>((props, re
 
   const onSvgLoad = (evt: LayoutChangeEvent) => {
     const { width, height } = evt.nativeEvent.layout
-    state.current.imageHeight = height
-    state.current.imageWidth = width
-    state.current.ratio = !width ? 0 : height / width
-
-    if (isWidthFixMode
-      ? state.current.viewWidth
-      : isHeightFixMode
-        ? state.current.viewHeight
-        : state.current.viewWidth && state.current.viewHeight) {
-      setRatio(state.current.ratio)
-      setImageWidth(width)
-      setImageHeight(height)
-      setViewSize(state.current.viewWidth!, state.current.viewHeight!, state.current.ratio)
-      setLoaded(true)
-    }
+    updateImageSize(width, height)
 
     bindload && bindload(
       getCustomEvent(
@@ -455,22 +459,7 @@ const Image = forwardRef<HandlerRef<RNImage, ImageProps>, ImageProps>((props, re
       getImageSize(
         src,
         (width: number, height: number) => {
-          state.current.imageWidth = width
-          state.current.imageHeight = height
-          state.current.ratio = !width ? 0 : height / width
-
-          if (isWidthFixMode
-            ? state.current.viewWidth
-            : isHeightFixMode
-              ? state.current.viewHeight
-              : state.current.viewWidth && state.current.viewHeight) {
-            setRatio(state.current.ratio)
-            setImageWidth(width)
-            setImageHeight(height)
-            setViewSize(state.current.viewWidth!, state.current.viewHeight!, state.current.ratio!)
-
-            setLoaded(true)
-          }
+          updateImageSize(width, height)
         },
         () => {
           setLoaded(true)

--- a/packages/webpack-plugin/lib/runtime/components/react/mpx-image.tsx
+++ b/packages/webpack-plugin/lib/runtime/components/react/mpx-image.tsx
@@ -371,7 +371,7 @@ const Image = forwardRef<HandlerRef<RNImage, ImageProps>, ImageProps>((props, re
   const onSvgLoad = (evt: LayoutChangeEvent) => {
     const { width, height } = evt.nativeEvent.layout
     state.current.imageHeight = height
-    setImageHeight(height)
+    state.current.imageWidth = width
     state.current.ratio = !width ? 0 : height / width
 
     if (isWidthFixMode


### PR DESCRIPTION
## 背景

  `mpx-image` 在处理 SVG 图片加载时，会在容器布局尺寸尚未就绪的情况下提前调用 `setImageHeight`，产生一次无效 render。

  同时，`onSvgLoad` 与普通图片的 `getImageSize` 回调中存在重复的图片尺寸同步逻辑。

  ## 修改内容

  - 将 SVG 图片宽高和比例先缓存到 `state.current`
  - 等图片尺寸和容器尺寸均就绪后，再批量更新 React state
  - 移除提前调用的 `setImageHeight`，避免额外 render
  - 抽取 `updateImageSize`，复用 SVG 和普通图片的尺寸更新流程