### PR TITLE
fix(webpack-plugin): 修复 Webpack 5.103+ 下小程序开发模式模板数据丢失

### DIFF
--- a/packages/webpack-plugin/lib/index.js
+++ b/packages/webpack-plugin/lib/index.js
@@ -384,6 +384,7 @@ class MpxWebpackPlugin {
         warnings.push(`webpack options: MpxWebpackPlugin accept options.output.filename to be ${outputFilename} only, custom options.output.filename will be ignored!`)
       }
       compiler.options.output.filename = compiler.options.output.chunkFilename = outputFilename
+      compiler.options.output.environment.globalThis = false
       if (this.options.optimizeSize && isProductionLikeMode(compiler.options)) {
         compiler.options.optimization.chunkIds = 'total-size'
         compiler.options.optimization.moduleIds = 'natural'
@@ -391,6 +392,8 @@ class MpxWebpackPlugin {
         compiler.options.output.globalObject = 'g'
         // todo chunkLoadingGlobal不具备项目唯一性，在多构建产物混编时可能存在问题，尤其在支付宝使用全局对象传递的情况下
         compiler.options.output.chunkLoadingGlobal = 'c'
+      } else {
+        compiler.options.output.globalObject = '__mpxChunkGlobal__'
       }
     }
 

--- a/packages/webpack-plugin/test/global-object.spec.js
+++ b/packages/webpack-plugin/test/global-object.spec.js
@@ -1,0 +1,43 @@
+const path = require('path')
+const webpack = require('webpack')
+const MpxWebpackPlugin = require('../lib')
+
+async function resolveOutputOptions ({ mode, mpxMode, optimizeSize }) {
+  const compiler = webpack({
+    mode,
+    entry: {},
+    output: {
+      path: path.resolve(__dirname, 'fixtures/global-object'),
+      globalObject: 'globalThis',
+      environment: {
+        globalThis: true
+      }
+    },
+    plugins: [new MpxWebpackPlugin({
+      mode: mpxMode,
+      srcMode: 'wx',
+      optimizeSize
+    })]
+  })
+  const outputOptions = {
+    globalObject: compiler.options.output.globalObject,
+    globalThis: compiler.options.output.environment.globalThis
+  }
+  await new Promise((resolve, reject) => {
+    compiler.close((error) => error ? reject(error) : resolve())
+  })
+  return outputOptions
+}
+
+describe('output global object', () => {
+  test.each([
+    ['serve miniprogram', { mode: 'development', mpxMode: 'wx', optimizeSize: false }, '__mpxChunkGlobal__', false],
+    ['optimized serve miniprogram', { mode: 'development', mpxMode: 'wx', optimizeSize: true }, '__mpxChunkGlobal__', false],
+    ['production miniprogram', { mode: 'production', mpxMode: 'wx', optimizeSize: false }, '__mpxChunkGlobal__', false],
+    ['optimized production miniprogram', { mode: 'production', mpxMode: 'wx', optimizeSize: true }, 'g', false],
+    ['web', { mode: 'development', mpxMode: 'web', optimizeSize: false }, 'globalThis', true],
+    ['react', { mode: 'development', mpxMode: 'ios', optimizeSize: false }, 'globalThis', true]
+  ])('uses the expected value for %s', async (name, options, globalObject, globalThis) => {
+    await expect(resolveOutputOptions(options)).resolves.toEqual({ globalObject, globalThis })
+  })
+})


### PR DESCRIPTION
## 问题描述

修复 #2578。

在 Webpack 5.103+ 环境下，小程序开发模式生成的页面可以正常执行 `setup()`，生命周期中也能读取响应式数据，但模板无法获取这些变量，表现为页面插值内容为空。

生产构建通常不受影响。

## 问题原因

Webpack 5.103+ 调整了 `global` 的处理逻辑：

当 `output.environment.globalThis` 为 `true` 时，Webpack 会直接把源码中的：

```js
global.currentInject

转换为：

globalThis.currentInject

```
与此同时，Mpx 会使用 output.globalObject 作为小程序 chunk 加载时的局部数据容器，并在每个 chunk 顶部注入：var ${globalObject} = {};

开发模式下，output.globalObject 可能被 Webpack 设置为 globalThis，最终生成：var globalThis = {};

因此，页面 chunk 和公共 bundle 中访问到的 globalThis 都是各自 chunk 内部的局部变量，并不是宿主环境的全局对象。无法被公共 bundle 中的运行时读取，导致模板 render 注入丢失。setup() 和生命周期仍然正常执行，所以控制台可以读取数据，但模板无法渲染。生产模式开启 optimizeSize 时，Mpx 已经将 output.globalObject 设置为短变量名 g，不会遮蔽 globalThis，因此问题主要出现在开发模式。

## 修复方式
本次在非 Web、非 React 的小程序构建中进行了两项调整。

1. 禁止 Webpack 直接将 global 输出为 globalThis
```js
compiler.options.output.environment.globalThis = false
```
这并不表示宿主环境一定不支持 globalThis，而是告诉 Webpack 不要假设 globalThis 一定存在。
Webpack 会因此保留完整的全局对象兼容处理，将业务代码中的：
```js

global.currentInject

转换为

__webpack_require__.g.currentInject

```
__webpack_require__.g 会依次尝试：
1. 宿主环境的 globalThis
2. this 或 new Function('return this')()
3. window
从而兼容不同的小程序运行环境。

2. 使用独立的 chunk 局部容器名称
对于非生产压缩场景，将 output.globalObject 设置为：__mpxChunkGlobal__

## 影响范围
调整仅作用于非 Web、非 React 构建：
- 小程序开发构建使用 __mpxChunkGlobal__；
- 小程序生产构建开启 optimizeSize 时继续使用 g；
- Web 构建行为不变；
- React/RN 构建行为不变。



