### PR TITLE
docs: 修复 sidebar 中 '使用TypeScript'  link 指向错误

### DIFF
--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -91,7 +91,7 @@ const sidebar: ExtendedSidebar = {
           text: '自定义路径',
           link: '/guide/advance/custom-output-path',
         },
-        { text: '使用TypeScript', link: '/guide/tool/ts' },
+        { text: '使用TypeScript', link: '/guide/advance/ts' },
         {
           text: '使用原子类',
           link: '/guide/advance/utility-first-css',


### PR DESCRIPTION
Fix: #2576 