### PR TITLE
fix(ci): 避免 PR 重复触发检查

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   tsc:


### PR DESCRIPTION
当前 test workflow 同时监听所有 push 和 pull_request，同仓库功能分支的 PR 会重复执行 tsc、lint 和 unit。

本次保留所有目标分支的 pull_request 检查，将 push 限制为 master，并增加 workflow_dispatch 手动运行入口。功能分支 PR 更新时只运行一组检查，合入 master 后仍会检查主干。

验证：已通过 YAML 语法及触发条件校验、git diff --check，并确认三个 job 的配置未变。完整 tsc、lint、unit 由本 PR 的 GitHub Actions 执行。